### PR TITLE
Quality/code improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
       run: dotnet build src/MainApp/CrowsNestMqtt.App.csproj --no-restore --configuration Release
 
     - name: Test with coverage
-      run: dotnet test --configuration Release --verbosity normal --filter "Category!=LocalOnly" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=./TestResults/coverage/
+      run: dotnet test --collect:"XPlat Code Coverage;Format=json,cobertura" --filter "Category!=LocalOnly"
     
     - name: Generate coverage report
       run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,6 +37,21 @@
                 "reveal": "always"
             },
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Generate code coverage",
+            "type": "shell",
+            "args": [
+                "dotnet test --collect:\"XPlat Code Coverage;Format=json,cobertura\" --filter \"Category!=LocalOnly\" && reportgenerator -reports:\"./tests/**/coverage.cobertura.xml\" -targetdir:\"./TestResults/CoverageReport\" -reporttypes:\"Html;Cobertura;JsonSummary\"",
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,21 +37,6 @@
                 "reveal": "always"
             },
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Generate code coverage",
-            "type": "shell",
-            "args": [
-                "dotnet test --collect:\"XPlat Code Coverage;Format=json,cobertura\" --filter \"Category!=LocalOnly\" && reportgenerator -reports:\"./tests/**/coverage.cobertura.xml\" -targetdir:\"./TestResults/CoverageReport\" -reporttypes:\"Html;Cobertura;JsonSummary\"",
-            ],
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "presentation": {
-                "reveal": "always"
-            },
-            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/src/Businesslogic/Exporter/JsonExporter.cs
+++ b/src/Businesslogic/Exporter/JsonExporter.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq; // Added for LINQ operations on UserProperties
 using MQTTnet;
 using CrowsNestMqtt.Utils; // For AppLogger
-using System.Text.Encodings.Web;
 using System.Text.Json.Serialization;
 
 // Define the JsonSerializerContext

--- a/src/MainApp/Program.cs
+++ b/src/MainApp/Program.cs
@@ -7,6 +7,9 @@ using CrowsNestMqtt.UI.Views;
 using CrowsNestMqtt.BusinessLogic.Services;
 using System.Timers; // Added for Timer
 using System.Runtime; // Added for GCSettings
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CrowsNestMqtt.UnitTests")]
 
 namespace CrowsNestMqtt.App;
 

--- a/src/MainApp/Program.cs
+++ b/src/MainApp/Program.cs
@@ -1,11 +1,7 @@
 using Avalonia;
 using Avalonia.ReactiveUI;
 using Serilog;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using Avalonia.Controls.ApplicationLifetimes;
-using CrowsNestMqtt.UI; // Use the App from UI project
 using CrowsNestMqtt.UI.ViewModels;
 using CrowsNestMqtt.UI.Views;
 using CrowsNestMqtt.BusinessLogic.Services;

--- a/src/UI/Services/IStatusBarService.cs
+++ b/src/UI/Services/IStatusBarService.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace CrowsNestMqtt.UI.Services;
 
 /// <summary>

--- a/src/UI/ViewLocator.cs
+++ b/src/UI/ViewLocator.cs
@@ -1,11 +1,9 @@
-using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using CrowsNestMqtt.UI.Views;
 using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.UI.ViewModels;
 using ReactiveUI;
-using System.Reactive;
 
 namespace CrowsNestMqtt.UI;
 

--- a/src/UI/ViewModels/JsonNodeViewModel.cs
+++ b/src/UI/ViewModels/JsonNodeViewModel.cs
@@ -1,5 +1,4 @@
 using ReactiveUI;
-using System;
 using System.Collections.ObjectModel;
 using System.Text.Json;
 using Avalonia.Media; // For Brushes

--- a/src/UI/ViewModels/JsonViewerViewModel.cs
+++ b/src/UI/ViewModels/JsonViewerViewModel.cs
@@ -1,7 +1,5 @@
 using ReactiveUI;
 using System.Collections.ObjectModel;
-using System.Reactive; // For Unit
-using System.Reactive.Linq; // For Select
 using System.Text.Json; // For JsonDocument, JsonElement
 using CrowsNestMqtt.Utils; // For AppLogger
 

--- a/src/UI/ViewModels/MainViewModelJsonContext.cs
+++ b/src/UI/ViewModels/MainViewModelJsonContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json; // Added for JSON formatting
+using System.Text.Json.Serialization; // Added for JSON formatting options
+
+namespace CrowsNestMqtt.UI.ViewModels;
+
+// Define the JsonSerializerContext for MainViewModel
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(JsonElement))]
+internal partial class MainViewModelJsonContext : JsonSerializerContext
+{
+}

--- a/src/UI/ViewModels/MessageViewModel.cs
+++ b/src/UI/ViewModels/MessageViewModel.cs
@@ -1,4 +1,3 @@
-using System; // Required for Guid and DateTime
 using MQTTnet; // Required for MqttApplicationMessage
 using ReactiveUI;
 using CrowsNestMqtt.BusinessLogic; // Assuming IMqttService is here

--- a/src/UI/ViewModels/MetadataItem.cs
+++ b/src/UI/ViewModels/MetadataItem.cs
@@ -1,0 +1,4 @@
+namespace CrowsNestMqtt.UI.ViewModels;
+
+// Simple record for DataGrid items
+public record MetadataItem(string Key, string Value);

--- a/src/UI/Views/MainView.axaml.cs
+++ b/src/UI/Views/MainView.axaml.cs
@@ -1,19 +1,15 @@
 using Avalonia; // Added for VisualTreeAttachmentEventArgs
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Input.Platform; // Added for IClipboard
 using Avalonia.Interactivity; // Added for RoutedEventArgs
-using Avalonia.ReactiveUI; // If using ReactiveUI bindings in code-behind
 using Avalonia.Threading; // Added for Dispatcher
 using CrowsNestMqtt.UI.ViewModels; // Namespace for MainViewModel
 
 using ReactiveUI;
 
 using System.Collections.Specialized; // Added for INotifyCollectionChanged
-using System.ComponentModel;
 using System.Reactive.Linq; // Added for INotifyPropertyChanged (optional but good practice)
 using System.Reactive; // Added for Unit
-using System; // Added for IDisposable
 using AvaloniaEdit.Editing; // Added for Selection
 namespace CrowsNestMqtt.UI.Views;
 

--- a/src/Utils/AppLogger.cs
+++ b/src/Utils/AppLogger.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace CrowsNestMqtt.Utils;
 
 /// <summary>

--- a/src/Utils/TopicRingBuffer.cs
+++ b/src/Utils/TopicRingBuffer.cs
@@ -1,7 +1,4 @@
 using MQTTnet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace CrowsNestMqtt.Utils;
 

--- a/tests/UnitTests/CommandParserServiceTests.cs
+++ b/tests/UnitTests/CommandParserServiceTests.cs
@@ -3,7 +3,6 @@ using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.BusinessLogic.Configuration;
 using CrowsNestMqtt.BusinessLogic.Commands;
 using CrowsNestMqtt.BusinessLogic.Exporter;
-using Xunit.Sdk; // Required for LINQ operations like SequenceEqual
 
 namespace CrowsNestMQTT.UnitTests;
 

--- a/tests/UnitTests/MqttEngineAdditionalTests.cs
+++ b/tests/UnitTests/MqttEngineAdditionalTests.cs
@@ -1,0 +1,280 @@
+using System.Reflection;
+
+using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests
+{
+    public class MqttEngineAdditionalTests
+    {
+        [Fact]
+        public void UpdateSettings_WithNewTopicBufferLimits_UpdatesLimits()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client",
+                KeepAliveInterval = TimeSpan.FromSeconds(60)
+            };
+            
+            var mqttEngine = new MqttEngine(settings);
+            
+            var newSettings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client",
+                KeepAliveInterval = TimeSpan.FromSeconds(60),
+                TopicSpecificBufferLimits = new List<TopicBufferLimit>
+                {
+                    new TopicBufferLimit("test/topic1", 10000),
+                    new TopicBufferLimit("test/topic2", 20000)
+                }
+            };
+            
+            // Act
+            mqttEngine.UpdateSettings(newSettings);
+            
+            // Use reflection to access private field
+            var field = typeof(MqttEngine).GetField("_topicSpecificBufferLimits", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var limits = field?.GetValue(mqttEngine) as IList<TopicBufferLimit>;
+            
+            // Assert
+            Assert.NotNull(limits);
+            Assert.Equal(2, limits.Count);
+            Assert.Equal("test/topic1", limits[0].TopicFilter);
+            Assert.Equal(10000, limits[0].MaxSizeBytes);
+            Assert.Equal("test/topic2", limits[1].TopicFilter);
+            Assert.Equal(20000, limits[1].MaxSizeBytes);
+        }
+        
+        [Fact]
+        public async Task ConnectAsync_SetsConnectingFlagDuringOperation()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            // Create MqttEngine with our mock client using reflection
+            var mqttEngine = new MqttEngine(settings);
+            
+            // Get the connecting field using reflection
+            var connectingField = typeof(MqttEngine).GetField("_connecting", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            
+            // Get the client field using reflection to check if connectTask is called
+            var clientField = typeof(MqttEngine).GetField("_client", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var client = clientField?.GetValue(mqttEngine);
+            
+            // Set the initial connecting state
+            if (connectingField != null)
+                connectingField.SetValue(mqttEngine, false);
+            
+            // Use a cancellation token that will immediately cancel to prevent actual connection
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            
+            try
+            {
+                // Act - try to connect with a cancelled token so it throws but still sets the flag
+                await mqttEngine.ConnectAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected exception due to cancelled token
+            }
+            
+            // Get the connecting flag value
+            bool? isConnecting = connectingField != null ? 
+                (bool?)connectingField.GetValue(mqttEngine) : null;
+            
+            // Assert
+            Assert.NotNull(client); // Client was created
+            Assert.NotNull(isConnecting); // Flag field exists
+            Assert.False(isConnecting.Value); // Flag is reset even after exception
+        }
+        
+        [Fact]
+        public void GetBufferSizeLimit_ReturnsSpecificLimitForMatchingTopic()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            var mqttEngine = new MqttEngine(settings);
+            
+            var newSettings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client",
+                TopicSpecificBufferLimits = new List<TopicBufferLimit>
+                {
+                    new TopicBufferLimit("test/specific", 5000),
+                    new TopicBufferLimit("test/#", 10000),
+                    new TopicBufferLimit("+/general", 15000)
+                }
+            };
+            
+            mqttEngine.UpdateSettings(newSettings);
+            
+            // Access the private method using reflection
+            var method = typeof(MqttEngine).GetMethod("GetBufferSizeLimit", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            
+            // Act & Assert
+            if (method != null)
+            {
+                // Test exact match
+                var exactMatchResult = method.Invoke(mqttEngine, new object[] { "test/specific" });
+                var exactMatchLimit = exactMatchResult != null ? (long)exactMatchResult : 0;
+                Assert.Equal(5000, exactMatchLimit);
+                
+                // Test wildcard match
+                var wildcardMatchResult = method.Invoke(mqttEngine, new object[] { "test/something" });
+                var wildcardMatchLimit = wildcardMatchResult != null ? (long)wildcardMatchResult : 0;
+                Assert.Equal(10000, wildcardMatchLimit);
+                
+                // Test + wildcard match
+                var plusWildcardMatchResult = method.Invoke(mqttEngine, new object[] { "anything/general" });
+                var plusWildcardMatchLimit = plusWildcardMatchResult != null ? (long)plusWildcardMatchResult : 0;
+                Assert.Equal(15000, plusWildcardMatchLimit);
+                
+                // Test default when no match
+                var defaultResult = method.Invoke(mqttEngine, new object[] { "no/match/here" });
+                var defaultLimit = defaultResult != null ? (long)defaultResult : 0;
+                Assert.Equal(MqttEngine.DefaultMaxTopicBufferSize, defaultLimit);
+            }
+        }
+        
+        [Fact]
+        public async Task DisconnectAsync_WorksCorrectly()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            // Create MqttEngine
+            var mqttEngine = new MqttEngine(settings);
+            
+            // Hook up event handler that will be called
+            mqttEngine.ConnectionStateChanged += (s, e) => 
+            {
+                // Just to verify the event gets raised without errors
+            };
+            
+            // Act - Just verify it doesn't throw an exception
+            await mqttEngine.DisconnectAsync();
+        }
+        
+        [Fact]
+        public void Dispose_ClearsResources()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            // Create MqttEngine
+            var mqttEngine = new MqttEngine(settings);
+            
+            // Access the _isDisposing field using reflection
+            var isDisposingField = typeof(MqttEngine).GetField("_isDisposing", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            
+            // Act
+            mqttEngine.Dispose();
+            
+            // Assert
+            if (isDisposingField != null)
+            {
+                var result = isDisposingField.GetValue(mqttEngine);
+                var isDisposing = result != null && (bool)result;
+                Assert.True(isDisposing);
+            }
+        }
+        
+        [Fact]
+        public async Task PublishAsync_SendsMessageCorrectly()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            // Create MqttEngine
+            var mqttEngine = new MqttEngine(settings);
+            
+            // Act & Assert - Just verify it doesn't throw an exception
+            // We can't properly mock the MQTTnet client without using internals
+            await mqttEngine.PublishAsync("test/topic", "test message", false);
+        }
+        
+        [Theory]
+        [InlineData("#", "a/b/c")]
+        [InlineData("a/#", "a/b/c")]
+        [InlineData("a/+/c", "a/b/c")]
+        [InlineData("a/b/c", "a/b/c")]
+        [InlineData("a/+/#", "a/b/c")]
+        [InlineData("+/+/+", "a/b/c")]
+        public void FindBestMatchingSubscription_ReturnsBestMatch(string filter, string topic)
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 1883,
+                ClientId = "test-client"
+            };
+            
+            var mqttEngine = new MqttEngine(settings);
+            
+            var subscriptions = new List<string>
+            {
+                "#",
+                "a/#",
+                "a/+/c",
+                "a/b/c",
+                "a/+/#",
+                "+/+/+"
+            };
+            
+            // Act - Call the FindBestMatchingSubscription method using reflection
+            var method = typeof(MqttEngine).GetMethod("FindBestMatchingSubscription", 
+                BindingFlags.NonPublic | BindingFlags.Static);
+            
+            if (method != null)
+            {
+                var result = method.Invoke(null, new object[] { subscriptions, topic }) as string;
+                
+                // Assert - Check that we get the expected filter as best match
+                // This is a simplification since we can't test the scoring directly
+                Assert.Equal(filter, result);
+            }
+        }
+    }
+}

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Reflection;
-using System.Collections.Generic; // Added for List
-using System.Threading;
-using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Protocol;
 using Xunit;

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -173,7 +173,7 @@ namespace CrowsNestMqtt.UnitTests
                 }
             };
 
-            await engine.ConnectAsync();
+            await engine.ConnectAsync(CancellationToken.None);
 
             // Act: Publish a test message using a publisher client.
             var factory = new MqttClientFactory();
@@ -195,7 +195,7 @@ namespace CrowsNestMqtt.UnitTests
             await publisher.PublishAsync(message, CancellationToken.None);
 
             // Wait for the message to be received
-            if (!messageReceivedEvent.Wait(TimeSpan.FromSeconds(10)))
+            if (!messageReceivedEvent.Wait(TimeSpan.FromSeconds(10), CancellationToken.None))
             {
                 Assert.Fail("Timeout waiting for message.");
             }
@@ -206,8 +206,8 @@ namespace CrowsNestMqtt.UnitTests
             Assert.Equal(payload, receivedArgs.ApplicationMessage.ConvertPayloadToString());
 
             // Cleanup
-            await publisher.DisconnectAsync();
-            await engine.DisconnectAsync();
+            await publisher.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
+            await engine.DisconnectAsync(CancellationToken.None);
         }
 
         [Fact]
@@ -238,7 +238,7 @@ namespace CrowsNestMqtt.UnitTests
                 }
             };
 
-            await engine.ConnectAsync();
+            await engine.ConnectAsync(CancellationToken.None);
 
             // Act: Publish a test message with an empty payload.
             var factory = new MqttClientFactory();
@@ -259,7 +259,7 @@ namespace CrowsNestMqtt.UnitTests
             await publisher.PublishAsync(message, CancellationToken.None);
 
             // Wait for the message to be received
-            if (!messageReceivedEvent.Wait(TimeSpan.FromSeconds(10)))
+            if (!messageReceivedEvent.Wait(TimeSpan.FromSeconds(10), CancellationToken.None))
             {
                 Assert.Fail("Timeout waiting for message with empty payload.");
             }
@@ -273,8 +273,8 @@ namespace CrowsNestMqtt.UnitTests
             Assert.Null(receivedArgs.ApplicationMessage.ConvertPayloadToString());
 
             // Cleanup
-            await publisher.DisconnectAsync();
-            await engine.DisconnectAsync();
+            await publisher.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
+            await engine.DisconnectAsync(CancellationToken.None);
         }
 
         [Fact]

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -1,0 +1,147 @@
+using Xunit;
+using CrowsNestMqtt.App;
+using System.Reflection;
+
+namespace CrowsNestMqtt.UnitTests
+{
+    /// <summary>
+    /// Tests for the Program class
+    /// </summary>
+    public class ProgramTests
+    {
+        // Helper method to safely invoke methods with proper null handling
+        private T? InvokeStaticMethod<T>(Type type, string methodName, object?[]? parameters = null)
+        {
+            var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method); // Verify method exists
+            
+            var result = method?.Invoke(null, parameters ?? Array.Empty<object>());
+            return result != null ? (T)result : default;
+        }
+        
+        [Fact]
+        public void LoadMqttEndpointFromEnv_ReturnsNullValuesWhenEnvironmentVariablesNotSet()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+
+            // Act - Using the correct tuple type
+            var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+
+            // Assert
+            Assert.Null(result.Item1); // Should return null when environment variable is not set
+            Assert.Null(result.Item2); // Should return null when environment variable is not set
+        }
+
+        [Fact]
+        public void LoadMqttEndpointFromEnv_ReturnsCustomValuesWhenEnvironmentVariablesSet()
+        {
+            // Arrange
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://test.mqtt.server:8883");
+
+                // Act - Using the correct tuple type
+                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+
+                // Assert
+                Assert.Equal("test.mqtt.server", result.Item1);
+                Assert.Equal(8883, result.Item2);
+            }
+            finally
+            {
+                // Clean up
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+            }
+        }
+
+        [Fact]
+        public void LoadMqttEndpointFromEnv_HandlesInvalidUriFormat()
+        {
+            // Arrange
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "invalid-uri");
+
+                // Act - Using the correct tuple type
+                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+
+                // Assert
+                Assert.Null(result.Item1); // Should return null for invalid URI
+                Assert.Null(result.Item2); // Should return null for invalid URI
+            }
+            finally
+            {
+                // Clean up
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+            }
+        }
+
+        // Skip this test since BuildAvaloniaApp requires proper UI initialization
+        [Fact(Skip = "Requires UI initialization which is not available in unit tests")]
+        public void BuildAvaloniaApp_ReturnsNonNullAppBuilder()
+        {
+            // This test is skipped as it requires UI initialization
+            // which is not possible in a headless unit test environment
+        }
+
+        // Skip this test since it depends on static state that may not be initialized in tests
+        [Fact(Skip = "Depends on static state that may not be properly initialized in tests")]
+        public void SetupGcTimerIfNeeded_SetsUpGcTimerCorrectly()
+        {
+            // This test is skipped as it requires static state initialization
+            // which is not ideal for unit tests
+        }
+
+        [Fact]
+        public void CurrentDomain_UnhandledException_LogsException()
+        {
+            // Create args
+            var exception = new Exception("Test exception");
+            var args = new UnhandledExceptionEventArgs(exception, isTerminating: false);
+            
+            // This should not throw
+            InvokeStaticMethod<object>(typeof(Program), "CurrentDomain_UnhandledException", 
+                new object?[] { this, args });
+        }
+
+        [Fact]
+        public void TaskScheduler_UnobservedTaskException_LogsException()
+        {
+            // Create a task with an exception
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.SetException(new Exception("Test task exception"));
+            var task = tcs.Task;
+            
+            try 
+            {
+                // Force the task to complete and throw
+                if (task.IsFaulted)
+                {
+                    // Just access to ensure it's faulted
+                    var _ = task.Exception;
+                }
+            }
+            catch
+            {
+                // Ignore
+            }
+            
+            // Create args with aggregate exception (the right type for UnobservedTaskException)
+            var args = new UnobservedTaskExceptionEventArgs(
+                new AggregateException(new Exception("Test task exception")));
+            
+            // This should not throw
+            InvokeStaticMethod<object>(typeof(Program), "TaskScheduler_UnobservedTaskException", 
+                new object?[] { this, args });
+        }
+
+        // Skip this test as it depends on static state
+        [Fact(Skip = "Depends on static state that may not be properly initialized in tests")]
+        public void GcTimerCallback_InvokesGarbageCollection()
+        {
+            // This test is skipped as it requires static state initialization
+            // which is not ideal for unit tests
+        }
+    }
+}

--- a/tests/UnitTests/TextExporterTests.cs
+++ b/tests/UnitTests/TextExporterTests.cs
@@ -147,7 +147,7 @@ public class TextExporterTests : IDisposable
         Assert.NotNull(filePath);
         Assert.True(File.Exists(filePath), $"File should exist at {filePath}");
         Assert.Equal(expectedFilename, Path.GetFileName(filePath));
-        var actualContent = await File.ReadAllTextAsync(filePath); // Await file read
+        var actualContent = await File.ReadAllTextAsync(filePath, CancellationToken.None); // Await file read
         Assert.Equal(expectedContent.TrimEnd().Replace("\r\n", "\n"), actualContent.TrimEnd().Replace("\r\n", "\n"));
     }
 
@@ -168,7 +168,7 @@ public class TextExporterTests : IDisposable
         Assert.NotNull(filePath);
         Assert.True(File.Exists(filePath));
         Assert.Equal(expectedFilename, Path.GetFileName(filePath));
-        var actualContent = await File.ReadAllTextAsync(filePath); // Await file read
+        var actualContent = await File.ReadAllTextAsync(filePath, CancellationToken.None); // Await file read
         Assert.Equal(expectedContent.TrimEnd().Replace("\r\n", "\n"), actualContent.TrimEnd().Replace("\r\n", "\n"));
         Assert.Contains("[No Payload]", actualContent);
     }
@@ -190,7 +190,7 @@ public class TextExporterTests : IDisposable
         Assert.NotNull(filePath);
         Assert.True(File.Exists(filePath));
         Assert.Equal(expectedFilename, Path.GetFileName(filePath));
-        var actualContent = await File.ReadAllTextAsync(filePath); // Await file read
+        var actualContent = await File.ReadAllTextAsync(filePath, CancellationToken.None); // Await file read
         Assert.Equal(expectedContent.TrimEnd().Replace("\r\n", "\n"), actualContent.TrimEnd().Replace("\r\n", "\n"));
         Assert.DoesNotContain("--- User Properties ---", actualContent);
     }
@@ -213,7 +213,7 @@ public class TextExporterTests : IDisposable
         Assert.NotNull(filePath);
         Assert.True(File.Exists(filePath));
         Assert.Equal(expectedFilename, Path.GetFileName(filePath));
-        var actualContent = await File.ReadAllTextAsync(filePath); // Await file read
+        var actualContent = await File.ReadAllTextAsync(filePath, CancellationToken.None); // Await file read
         Assert.Equal(expectedContent.TrimEnd().Replace("\r\n", "\n"), actualContent.TrimEnd().Replace("\r\n", "\n"));
         // Check the line specifically, accounting for potential line ending differences
         Assert.Contains($"Correlation Data: \n", actualContent.Replace("\r\n", "\n"));

--- a/tests/UnitTests/TextExporterTests.cs
+++ b/tests/UnitTests/TextExporterTests.cs
@@ -1,14 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks; // Keep for async file reading
+
 using CrowsNestMqtt.BusinessLogic.Exporter;
 using CrowsNestMqtt.Utils;
+
 using MQTTnet;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
+
 using Xunit;
 
 namespace CrowsNestMqtt.UnitTests;

--- a/tests/UnitTests/TopicRingBufferTests.cs
+++ b/tests/UnitTests/TopicRingBufferTests.cs
@@ -1,10 +1,7 @@
 using Xunit;
 using CrowsNestMqtt.Utils;
 using MQTTnet;
-using System;
-using System.Linq;
 using System.Text;
-using System.Collections.Generic;
 
 namespace CrowsNestMqtt.UnitTests
 {

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -4,23 +4,18 @@
     <AssemblyName>CrowsNestMqtt.UnitTests</AssemblyName>
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <CollectCoverage>true</CollectCoverage>
-    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <CoverletOutput>$(MSBuildProjectDirectory)/../../TestResults/</CoverletOutput>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/UnitTests/ViewModels/CommandInterfaceTests.cs
+++ b/tests/UnitTests/ViewModels/CommandInterfaceTests.cs
@@ -6,13 +6,9 @@ using CrowsNestMqtt.UI.ViewModels;
 using CrowsNestMqtt.UI.Services; // Added for IStatusBarService
 using NSubstitute;
 using MQTTnet;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using Xunit;
-using System.Threading.Tasks;
 
 namespace CrowsNestMqtt.UnitTests.ViewModels
 {

--- a/tests/UnitTests/ViewModels/CommandInterfaceTests.cs
+++ b/tests/UnitTests/ViewModels/CommandInterfaceTests.cs
@@ -52,7 +52,7 @@ namespace CrowsNestMqtt.UnitTests.ViewModels
             _commandParserService.Received(1).ParseInput(commandText, Arg.Any<SettingsData>()); // Use Arg.Any for Received check too
             // Should update settings and connect as a result of the :connect command
             // _mqttEngine.Received(1).UpdateSettings(Arg.Is<MqttConnectionSettings>(s => s != null)); // Cannot verify non-virtual method on class substitute
-            await _mqttEngine.Received(1).ConnectAsync();
+            await _mqttEngine.Received(1).ConnectAsync(Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/tests/UnitTests/ViewModels/MainViewModelJsonContextTests.cs
+++ b/tests/UnitTests/ViewModels/MainViewModelJsonContextTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Xunit;
+using CrowsNestMqtt.UI.ViewModels;
+
+namespace CrowsNestMqtt.UnitTests.ViewModels
+{
+    public class MainViewModelJsonContextTests
+    {
+        [Fact]
+        public void JsonContext_SerializeJsonElement()
+        {
+            // Arrange
+            var element = JsonDocument.Parse("{ \"test\": \"value\" }").RootElement;
+            
+            // Act
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            options.TypeInfoResolver = MainViewModelJsonContext.Default;
+            var json = JsonSerializer.Serialize(element, options);
+            
+            // Assert
+            Assert.Contains("test", json);
+            Assert.Contains("value", json);
+        }
+
+        [Fact]
+        public void JsonContext_DeserializeJsonElement()
+        {
+            // Arrange
+            string jsonString = "{ \"test\": \"value\" }";
+            
+            // Act
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            options.TypeInfoResolver = MainViewModelJsonContext.Default;
+            var element = JsonSerializer.Deserialize<JsonElement>(jsonString, options);
+            
+            // Assert
+            Assert.Equal("value", element.GetProperty("test").GetString());
+        }
+        
+        [Fact]
+        public void JsonContext_SerializeDeserializeWithTypeInfo()
+        {
+            // Arrange
+            var element = JsonDocument.Parse("{ \"key\": \"value\", \"nested\": { \"inner\": 123 } }").RootElement;
+            
+            // Act
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            options.TypeInfoResolver = MainViewModelJsonContext.Default;
+            var json = JsonSerializer.Serialize(element, options);
+            var deserializedElement = JsonSerializer.Deserialize<JsonElement>(json, options);
+            
+            // Assert
+            Assert.Equal("value", deserializedElement.GetProperty("key").GetString());
+            Assert.Equal(123, deserializedElement.GetProperty("nested").GetProperty("inner").GetInt32());
+        }
+    }
+}

--- a/tests/UnitTests/ViewModels/MessageDisplayTests.cs
+++ b/tests/UnitTests/ViewModels/MessageDisplayTests.cs
@@ -5,11 +5,9 @@ using CrowsNestMqtt.UI.Services; // Added for IStatusBarService
 using DynamicData;
 using NSubstitute;
 using MQTTnet;
-using System;
 using System.Buffers;
 using System.Reflection;
 using System.Text;
-using System.Collections.Generic;
 using Xunit;
 
 namespace CrowsNestMqtt.UnitTests.ViewModels

--- a/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
+++ b/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
@@ -1,16 +1,11 @@
 using CrowsNestMqtt.BusinessLogic;
-using CrowsNestMqtt.BusinessLogic.Commands;
 using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.UI.ViewModels;
 using NSubstitute;
 using MQTTnet;
-using System;
 using System.Buffers;
 using System.Reactive.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
-using CrowsNestMqtt.BusinessLogic.Configuration; // Required for MqttConnectionSettings
 
 namespace CrowsNestMqtt.UnitTests.ViewModels
 {

--- a/tests/UnitTests/ViewModels/PayloadVisualizationTests.cs
+++ b/tests/UnitTests/ViewModels/PayloadVisualizationTests.cs
@@ -4,11 +4,8 @@ using CrowsNestMqtt.UI.ViewModels;
 using NSubstitute;
 using CrowsNestMqtt.UI.Services; // Added for IStatusBarService
 using MQTTnet;
-using System;
-using System.Buffers;
 using System.Reflection;
 using System.Text;
-using System.Reactive;
 using Xunit;
 using System.Text.Json; // Added for JsonValueKind
 

--- a/tests/UnitTests/ViewModels/SearchFilteringTests.cs
+++ b/tests/UnitTests/ViewModels/SearchFilteringTests.cs
@@ -5,13 +5,8 @@ using CrowsNestMqtt.UI.ViewModels;
 using CrowsNestMqtt.UI.Services; // Added for IStatusBarService
 using DynamicData;
 using NSubstitute;
-using MQTTnet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using Xunit;
 
 namespace CrowsNestMqtt.UnitTests.ViewModels

--- a/tests/UnitTests/ViewModels/SettingsViewModelJsonContextTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelJsonContextTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Xunit;
+using CrowsNestMqtt.UI.ViewModels;
+using System.Collections.ObjectModel;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+
+namespace CrowsNestMqtt.UnitTests.ViewModels
+{
+    public class SettingsViewModelJsonContextTests
+    {
+        private class TestViewModel
+        {
+            public ObservableCollection<TopicBufferLimitViewModel> Limits { get; set; } = 
+                new ObservableCollection<TopicBufferLimitViewModel>();
+        }
+        
+        [Fact]
+        public void SettingsViewModel_Serialization()
+        {
+            // Arrange - Create a test settings view model
+            var model = new SettingsViewModel();
+            
+            // Act
+            var json = JsonSerializer.Serialize(model);
+            
+            // Assert
+            Assert.NotNull(json);
+            Assert.NotEqual("{}", json);
+        }
+        
+        [Fact]
+        public void SettingsData_Serialization()
+        {
+            // Arrange
+            var settings = new SettingsData(
+                "test.mqtt.server",  // Hostname
+                8883,                // Port
+                "test-client",       // ClientId
+                60,                  // KeepAliveIntervalSeconds
+                true,                // CleanSession
+                300,                 // SessionExpiryIntervalSeconds
+                new AnonymousAuthenticationMode() // AuthMode
+            );
+            
+            // Act
+            var json = JsonSerializer.Serialize(settings);
+            
+            // Assert
+            Assert.NotNull(json);
+            Assert.Contains("test.mqtt.server", json);
+            Assert.Contains("8883", json);
+        }
+        
+        [Fact]
+        public void TestTopicBufferLimitViewModel_Serialization()
+        {
+            // Arrange
+            var testViewModel = new TestViewModel();
+            testViewModel.Limits.Add(new TopicBufferLimitViewModel 
+            {
+                TopicFilter = "test/topic",
+                MaxSizeBytes = 1000
+            });
+            
+            // Act
+            var json = JsonSerializer.Serialize(testViewModel);
+            
+            // Assert
+            Assert.NotNull(json);
+            Assert.Contains("test/topic", json);
+            Assert.Contains("1000", json);
+        }
+        
+        // Skip this test since the polymorphic serialization is not working as expected
+        // We'd need to set up the correct JsonTypeInfo and serialization context
+        [Fact(Skip = "Polymorphic serialization requires a more complex test setup")]
+        public void AuthenticationMode_Serialization()
+        {
+            // This test is skipped because it requires proper JsonTypeInfo setup
+            // which is beyond the scope of this unit test
+        }
+    }
+}

--- a/tests/UnitTests/ViewModels/TopicTreeManagementTests.cs
+++ b/tests/UnitTests/ViewModels/TopicTreeManagementTests.cs
@@ -1,8 +1,8 @@
-using CrowsNestMqtt.BusinessLogic;
 using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.UI.ViewModels;
+
 using NSubstitute;
-using System.Linq;
+
 using Xunit;
 
 namespace CrowsNestMqtt.UnitTests.ViewModels

--- a/tools/generateCodeCoverage.ps1
+++ b/tools/generateCodeCoverage.ps1
@@ -1,0 +1,3 @@
+dotnet test --collect:"XPlat Code Coverage;Format=json,cobertura" --filter "Category!=LocalOnly" /p:CoverletOutput=./TestResults/coverage/   
+reportgenerator -reports:"./tests/**/coverage.cobertura.xml" -targetdir:"./TestResults/CoverageReport" -reporttypes:"Html;Cobertura;JsonSummary"
+start .\TestResults\CoverageReport\index.htm


### PR DESCRIPTION
This pull request includes multiple changes across the codebase, focusing on improving code maintainability, introducing new functionality, and cleaning up unused imports. The most significant updates include enhancing the `MainViewModel` with cancellation token support for commands, moving the `MetadataItem` record to its own file, and introducing a `JsonSerializerContext` for JSON formatting.

### Functional Enhancements:
* Updated `ConnectCommand` and `DisconnectCommand` in `MainViewModel` to support `CancellationToken`, allowing better task cancellation handling. (`[[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL235-R213)`, `[[2]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL371-R349)`, `[[3]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL751-R735)`, `[[4]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL768-R760)`)
* Added `[assembly: InternalsVisibleTo("CrowsNestMqtt.UnitTests")]` in `Program.cs` to enable internal access for unit testing. (`[src/MainApp/Program.csL4-R12](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0L4-R12)`)

### Code Refactoring:
* Extracted the `MetadataItem` record from `MainViewModel` into its own file, `MetadataItem.cs`, for better modularity. (`[[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL39-L48)`, `[[2]](diffhunk://#diff-220ddade476982594162e986ae9e2210946dc890e4c0ff62accbd9cbe4c780dfR1-R4)`)
* Moved the `MainViewModelJsonContext` class from `MainViewModel` to a new file, `MainViewModelJsonContext.cs`, to separate concerns. (`[[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL39-L48)`, `[[2]](diffhunk://#diff-5d5146c0c2fc05617dd371b2fb08ffbb758ddf9d6c39b2b7ae7ff382bf77f67cR1-R11)`)

### Build and Test Workflow:
* Simplified the test command in `.github/workflows/build-and-test.yml` to use `XPlat Code Coverage` with multiple formats, improving maintainability. (`[.github/workflows/build-and-test.ymlL52-R52](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948L52-R52)`)

### Code Cleanup:
* Removed unused imports across multiple files, including `JsonExporter.cs`, `MessageViewModel.cs`, and `AppLogger.cs`, to reduce clutter and improve readability. (`[[1]](diffhunk://#diff-bfb94c5f6af181cadf1db88c8440b61b5cd770dbc56ab601a27374b5651245e2L9)`, `[[2]](diffhunk://#diff-2de05c75d956f9e9de05fa7d32f05bb07d0b273123fb3a32561166bd8aab3217L1)`, `[[3]](diffhunk://#diff-e3c5adb39cbc4ed0a342baeb898e89ffc14bbbfd16a58d0c3995eeb3326bd75cL1-L2)`, and others)