### PR TITLE
Add TLS support and related settings to MQTT connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Shows all the metadata of the message selected in history view. Including standa
 Configure how the client connects to your MQTT broker:
 - **Hostname**: The broker address (default: `localhost`).
 - **Port**: The broker port (default: `1883`).
+- **Use TLS**: Enable to connect to the broker using TLS encryption. If enabled, the client will allow untrusted certificates and ignore certificate chain and revocation errors. You can also set this via the `:setusetls <true|false>` command.
 - **Client ID**: Optional identifier for the client. If left blank, one is generated.
 - **Keep Alive Interval**: Time in seconds between keep-alive pings (default: `60`).
 - **Clean Session**: If enabled, the broker does not retain session data after disconnect.
@@ -82,6 +83,7 @@ Crow's Nest MQTT provides a command interface (likely accessible via a dedicated
 *   `:setauthmode <anonymous|userpass|enhanced>` - Set the authentication mode.
 *   `:setauthmethod <method>` - Set the authentication method for enhanced authentication (e.g., `SCRAM-SHA-1`, `K8S-SAT`).
 *   `:setauthdata <data>` - Set the authentication data for enhanced authentication (method-specific data).
+*   `:setusetls <true|false>` - Set whether to use TLS for the MQTT connection. When set to `true`, the client will connect using TLS, allow untrusted certificates, and ignore certificate errors.
 *   `[search_term]` - Any text entered without a `:` prefix is treated as a search term to filter messages.
 
 ## Enhanced Authentication
@@ -97,6 +99,8 @@ You can set the authentication mode to `enhanced` using the `:setauthmode` comma
 
 ```
 :setauthmode enhanced
+:setauthmethod ABC
+:setauthdata CAFE
 ```
 
 When connecting to a broker with Enhanced Authentication, the client and broker will exchange authentication data until the authentication process is complete.

--- a/src/Businesslogic/Commands/CommandType.cs
+++ b/src/Businesslogic/Commands/CommandType.cs
@@ -45,6 +45,8 @@ public enum CommandType
     SetAuthMethod,
     /// <summary> Set the MQTT authentication data. </summary>
     SetAuthData,
+    /// <summary> Set the MQTT TLS usage flag. </summary>
+    SetUseTls,
     /// <summary> Represents an unrecognized or invalid command. </summary>
     Unknown
 }

--- a/src/Businesslogic/Configutation/SettingsData.cs
+++ b/src/Businesslogic/Configutation/SettingsData.cs
@@ -12,7 +12,8 @@ public record SettingsData(
     uint? SessionExpiryIntervalSeconds = 300,
     AuthenticationMode? AuthMode = null,
     ExportTypes? ExportFormat = null,
-    string? ExportPath = null)
+    string? ExportPath = null,
+    bool UseTls = false)
 {
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; init; } = new List<TopicBufferLimit>();
     // Ensure AuthMode is never null, defaulting to Anonymous if not provided.

--- a/src/Businesslogic/MqttConnectionSettings.cs
+++ b/src/Businesslogic/MqttConnectionSettings.cs
@@ -18,4 +18,5 @@ public class MqttConnectionSettings
     public uint? SessionExpiryInterval { get; set; } = 3600;
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; set; } = new List<TopicBufferLimit>();
     public AuthenticationMode AuthMode { get; set; } = new AnonymousAuthenticationMode();
+    public bool UseTls { get; set; } = false;
 }

--- a/src/Businesslogic/MqttEngine.cs
+++ b/src/Businesslogic/MqttEngine.cs
@@ -129,6 +129,21 @@ public class MqttEngine : IMqttService // Implement the interface
             builder.WithClientId(_settings.ClientId);
         }
 
+        // TLS support
+        if (_settings.UseTls)
+        {
+            var tlsOptions = new MqttClientTlsOptions
+            {
+                UseTls = true,
+                AllowUntrustedCertificates = true,
+                IgnoreCertificateChainErrors = true,
+                IgnoreCertificateRevocationErrors = true,
+                SslProtocol = System.Security.Authentication.SslProtocols.None, //let OS choose
+                CertificateValidationHandler = _ => true,
+            };
+            builder.WithTlsOptions(tlsOptions);
+        }
+
         // Add credentials based on AuthMode
         switch (_settings.AuthMode)
         {

--- a/src/Businesslogic/Services/CommandParserService.cs
+++ b/src/Businesslogic/Services/CommandParserService.cs
@@ -286,6 +286,18 @@ public class CommandParserService : ICommandParserService
                 }
                 return CommandResult.Failure("Invalid arguments for :setauthdata. Expected: :setauthdata <data>");
 
+            case "setusetls":
+                if (arguments.Count == 1)
+                {
+                    var arg = arguments[0].ToLowerInvariant();
+                    if (arg == "true" || arg == "false")
+                    {
+                        return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetUseTls, arguments));
+                    }
+                    return CommandResult.Failure("Invalid argument for :setusetls. Expected: :setusetls <true|false>");
+                }
+                return CommandResult.Failure("Invalid arguments for :setusetls. Expected: :setusetls <true|false>");
+
             case "settings":
                 if (arguments.Count == 0)
                 {

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -73,6 +73,13 @@ public class SettingsViewModel : ReactiveObject
     private bool _isLoading = false; // Flag to prevent saving during initial load
 #pragma warning restore IDE0044 // Add readonly modifier
 
+    private bool _useTls = false;
+    public bool UseTls
+    {
+        get => _useTls;
+        set => this.RaiseAndSetIfChanged(ref _useTls, value);
+    }
+
     public SettingsViewModel()
     {
         ExportPath = _exportFolderPath; // Set default before loading
@@ -111,7 +118,8 @@ public class SettingsViewModel : ReactiveObject
             this.WhenAnyValue(x => x.AuthPassword),
             this.WhenAnyValue(x => x.AuthenticationMethod),
             this.WhenAnyValue(x => x.AuthenticationData),
-            (_, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
+            this.WhenAnyValue(x => x.UseTls),
+            (_, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
 
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
@@ -310,7 +318,8 @@ public class SettingsViewModel : ReactiveObject
             SessionExpiryIntervalSeconds,
             authModeSetting,
             ExportFormat,
-            ExportPath
+            ExportPath,
+            UseTls
         )
         {
             TopicSpecificBufferLimits = topicLimits
@@ -327,6 +336,7 @@ public class SettingsViewModel : ReactiveObject
         SessionExpiryIntervalSeconds = settingsData.SessionExpiryIntervalSeconds;
         ExportFormat = settingsData.ExportFormat;
         ExportPath = settingsData.ExportPath;
+        UseTls = settingsData.UseTls;
         TopicSpecificLimits.Clear();
         if (settingsData.TopicSpecificBufferLimits != null)
         {

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -239,7 +239,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- Increased to 19 rows for Application Settings -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto, Auto" Margin="5"> <!-- Increased to 19 rows for Application Settings -->
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -271,58 +271,62 @@
                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Port:"/>
                 <NumericUpDown Grid.Row="2" Grid.Column="1" Value="{Binding Settings.Port, Mode=TwoWay, StringFormat=N0}" ParsingNumberStyle="Integer" Minimum="1" Maximum="65535"/>
 
+                <!-- Use TLS -->
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Use TLS:"/>
+                <CheckBox Grid.Row="3" Grid.Column="1" IsChecked="{Binding Settings.UseTls, Mode=TwoWay}" Margin="10,0,0,0"/>
+
                 <!-- Client ID -->
-                <TextBlock Grid.Row="3" Grid.Column="0" Text="Client ID:"/>
-                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" Watermark="(auto-generated)"/>
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Client ID:"/>
+                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" Watermark="(auto-generated)"/>
 
                 <!-- Keep Alive -->
-                <TextBlock Grid.Row="4" Grid.Column="0" Text="Keep Alive (s):"/>
-                <NumericUpDown Grid.Row="4" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
+                <TextBlock Grid.Row="5" Grid.Column="0" Text="Keep Alive (s):"/>
+                <NumericUpDown Grid.Row="5" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
                 
                 <!-- Clean Session -->
-                <TextBlock Grid.Row="5" Grid.Column="0" Text="Clean Session:"/>
-                <CheckBox Grid.Row="5" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="Clean Session:"/>
+                <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
 
                 <!-- Session Expiry -->
-                <TextBlock Grid.Row="6" Grid.Column="0" Text="Session Expiry (s):"/>
-                <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Vertical" Spacing="5">
+                <TextBlock Grid.Row="7" Grid.Column="0" Text="Session Expiry (s):"/>
+                <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Vertical" Spacing="5">
                     <NumericUpDown Value="{Binding Settings.SessionExpiryIntervalSeconds, Mode=TwoWay}" MinWidth="120"  FormatString="N0" Minimum="0" Watermark="(infinite)"/>
                     <TextBlock Text="(0 = expires immediately, empty = infinite)" FontSize="10"/>
                 </StackPanel>
 
                 <!-- Authentication Mode -->
-                <TextBlock Grid.Row="7" Grid.Column="0" Text="Auth Mode:"/>
-                <ComboBox Grid.Row="7" Grid.Column="1"
+                <TextBlock Grid.Row="8" Grid.Column="0" Text="Auth Mode:"/>
+                <ComboBox Grid.Row="8" Grid.Column="1"
                             ItemsSource="{Binding Settings.AvailableAuthenticationModes}"
                             SelectedItem="{Binding Settings.SelectedAuthMode, Mode=TwoWay}"
                             MinWidth="220"/>
 
                 <!-- Auth Username (Conditionally Visible) -->
-                <TextBlock Grid.Row="8" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox Grid.Row="8" Grid.Column="1"
+                <TextBlock Grid.Row="9" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox Grid.Row="9" Grid.Column="1"
                          Text="{Binding Settings.AuthUsername, Mode=TwoWay}"
                          Watermark="Enter username"
                          IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
 
                 <!-- Auth Password (Conditionally Visible) -->
-                <TextBlock Grid.Row="9" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox  Grid.Row="9" Grid.Column="1"
+                <TextBlock Grid.Row="10" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox  Grid.Row="10" Grid.Column="1"
                              Text="{Binding Settings.AuthPassword, Mode=TwoWay}"
                              Watermark="Enter password" PasswordChar="*"
                              IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
                 
                 <!-- Enhanced Authentication Header -->
-                <TextBlock Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Method -->
-                <TextBlock Grid.Row="11" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
-                <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" Watermark="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="12" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" Watermark="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Data -->
-                <TextBlock Grid.Row="12" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="13" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
                 
                 <ScrollViewer                            
-                            Grid.Row="12"
+                            Grid.Row="13"
                             Grid.Column="1"
                             IsVisible="{Binding Settings.IsEnhancedAuthSelected}"
                             HorizontalScrollBarVisibility="Visible"
@@ -340,21 +344,21 @@
                 </ScrollViewer>
 
                 <!-- General Settings Header -->
-                <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Export Format -->
-                <TextBlock Grid.Row="14" Grid.Column="0" Text="Export Format:"/>
-                <ComboBox Grid.Row="14" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
+                <TextBlock Grid.Row="15" Grid.Column="0" Text="Export Format:"/>
+                <ComboBox Grid.Row="15" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
 
                 <!-- Export Path -->
-                <TextBlock Grid.Row="15" Grid.Column="0" Text="Export Path:"/>
-                <TextBox Grid.Row="15" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
+                <TextBlock Grid.Row="16" Grid.Column="0" Text="Export Path:"/>
+                <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
 
                 <!-- Application Settings Header -->
-                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Topic Buffer Limits List -->
-                <ItemsControl Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
+                <ItemsControl Grid.Row="18" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:TopicBufferLimitViewModel}">
                             <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto" Margin="0,2">
@@ -367,7 +371,7 @@
                 </ItemsControl>
                 
                 <!-- Add New Limit Button -->
-                <Button Grid.Row="18" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                <Button Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -343,5 +343,32 @@ namespace CrowsNestMqtt.UnitTests
             Assert.Equal("Enhanced Authentication", options.AuthenticationMethod);
             Assert.Equal("my-jwt-token", System.Text.Encoding.UTF8.GetString(options.AuthenticationData));
         }
+
+        [Fact]
+        public void BuildMqttOptions_WithUseTls_ShouldSetTlsOptions()
+        {
+            // Arrange
+            var settings = new MqttConnectionSettings
+            {
+                Hostname = "localhost",
+                Port = 8883,
+                UseTls = true
+            };
+            var engine = new MqttEngine(settings);
+
+            // Act
+            var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+            var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+            // Assert
+            Assert.NotNull(options);
+            Assert.NotNull(options.ChannelOptions);
+            var tlsOptions = options.ChannelOptions.TlsOptions;
+            Assert.NotNull(tlsOptions);
+            Assert.True(tlsOptions.UseTls);
+            Assert.True(tlsOptions.AllowUntrustedCertificates);
+            Assert.True(tlsOptions.IgnoreCertificateChainErrors);
+            Assert.True(tlsOptions.IgnoreCertificateRevocationErrors);
+        }
     }
 }

--- a/tests/UnitTests/Services/CommandParserServiceTests.cs
+++ b/tests/UnitTests/Services/CommandParserServiceTests.cs
@@ -224,5 +224,39 @@ namespace CrowsNestMqtt.UnitTests.Services
             Assert.Null(result.ParsedCommand);
             Assert.Equal("Invalid arguments for :setauthdata. Expected: :setauthdata <data>", result.ErrorMessage);
         }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseCommand_SetUseTls_ValidArgs_ShouldSucceed(string value)
+        {
+            var input = $":setusetls {value}";
+            var result = _parser.ParseCommand(input, _defaultSettings);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.ParsedCommand);
+            Assert.Equal(CommandType.SetUseTls, result.ParsedCommand.Type);
+            Assert.Single(result.ParsedCommand.Arguments);
+            Assert.Equal(value, result.ParsedCommand.Arguments[0]);
+        }
+
+        [Fact]
+        public void ParseCommand_SetUseTls_InvalidArg_ShouldFail()
+        {
+            var input = ":setusetls maybe";
+            var result = _parser.ParseCommand(input, _defaultSettings);
+            Assert.False(result.IsSuccess);
+            Assert.Null(result.ParsedCommand);
+            Assert.Equal("Invalid argument for :setusetls. Expected: :setusetls <true|false>", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ParseCommand_SetUseTls_NoArgs_ShouldFail()
+        {
+            var input = ":setusetls";
+            var result = _parser.ParseCommand(input, _defaultSettings);
+            Assert.False(result.IsSuccess);
+            Assert.Null(result.ParsedCommand);
+            Assert.Equal("Invalid arguments for :setusetls. Expected: :setusetls <true|false>", result.ErrorMessage);
+        }
     }
 }

--- a/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -22,6 +22,24 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void Into_SettingsData_HasCorrectUseTls()
+    {
+        var vm = new SettingsViewModel();
+        vm.UseTls = true;
+        var settingsData = vm.Into();
+        Assert.True(settingsData.UseTls);
+    }
+
+    [Fact]
+    public void From_SettingsData_SetsUseTls()
+    {
+        var settingsData = new SettingsData("host", 1, "client", 1, true, 1, new AnonymousAuthenticationMode(), null, null, true);
+        var vm = new SettingsViewModel();
+        vm.From(settingsData);
+        Assert.True(vm.UseTls);
+    }
+
+    [Fact]
     public void IsEnhancedAuthSelected_IsTrue_WhenAuthModeIsEnhanced()
     {
         // Arrange
@@ -58,6 +76,7 @@ public class SettingsViewModelTests
         var vm = new SettingsViewModel
         {
             SelectedAuthMode = SettingsViewModel.AuthModeSelection.Enhanced,
+            AuthenticationMethod = null,
             AuthenticationData = "my-token"
         };
 
@@ -65,8 +84,8 @@ public class SettingsViewModelTests
         var settingsData = vm.Into();
 
         // Assert
-        Assert.Null(settingsData.AuthenticationMethod);
-        Assert.Equal("my-token", settingsData.AuthenticationData);
+        Assert.Equal(vm.AuthenticationMethod, (settingsData.AuthMode as EnhancedAuthenticationMode)!.AuthenticationMethod);
+        Assert.Equal("my-token", (settingsData.AuthMode as EnhancedAuthenticationMode)!.AuthenticationData);
         Assert.IsType<EnhancedAuthenticationMode>(settingsData.AuthMode);
     }
     


### PR DESCRIPTION
This pull request introduces TLS support for MQTT connections, allowing users to enable or disable TLS encryption through settings, commands, and the UI. The changes span multiple files, adding functionality to configure TLS usage, handle related commands, and integrate the feature into the application's settings and connection logic.

### TLS Support Implementation

* **Command and Configuration Updates**:
  - Added a new `:setusetls <true|false>` command to enable or disable TLS usage for MQTT connections. This command accepts `true` or `false` as arguments. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86) [[3]](diffhunk://#diff-36e9c5fa751c2134a8acc2d6c98cb98f84460d7fe34cabaacc9ac87b8a14a720R289-R300)
  - Introduced a new `CommandType.SetUseTls` in `CommandType.cs` to handle the TLS-related command. (`src/Businesslogic/Commands/CommandType.cs` [src/Businesslogic/Commands/CommandType.csR48-R49](diffhunk://#diff-ef69884bea49983a33f456d57f1dbe392162e2e2d270ed874454a6ec333c6281R48-R49))
  - Added a `UseTls` property to `SettingsData` and `MqttConnectionSettings`, defaulting to `false`. (`src/Businesslogic/Configutation/SettingsData.cs` [[1]](diffhunk://#diff-3481804419bb0d383c3facd2fb9310b4e4479a5ca48476fdce5aae49fbf8447bL15-R16) `src/Businesslogic/MqttConnectionSettings.cs` [[2]](diffhunk://#diff-4a30e7c2163089c9663f6893f5481abc5d0561f4463943c1ad37b9cd504f29c2R21)

* **Connection Logic**:
  - Updated the MQTT connection logic to include TLS options when `UseTls` is enabled. The configuration allows untrusted certificates and ignores certificate chain and revocation errors. (`src/Businesslogic/MqttEngine.cs` [src/Businesslogic/MqttEngine.csR132-R146](diffhunk://#diff-3d8fb5f611c1a85b8531d6b657d7e5deb9d1470d6553cede6ff5398a356baa75R132-R146))

### UI and Settings Integration

* **Settings ViewModel**:
  - Added a `UseTls` property to `SettingsViewModel` to bind TLS settings to the UI. Updated the `Into` and `From` methods to include `UseTls`. (`src/UI/ViewModels/SettingsViewModel.cs` [[1]](diffhunk://#diff-4c3f0e90b3cbbe79061beb9e8c977595ea9849f0ce27ee0a3051c9ed55ca65caR76-R82) [[2]](diffhunk://#diff-4c3f0e90b3cbbe79061beb9e8c977595ea9849f0ce27ee0a3051c9ed55ca65caL313-R322) [[3]](diffhunk://#diff-4c3f0e90b3cbbe79061beb9e8c977595ea9849f0ce27ee0a3051c9ed55ca65caR339)

* **UI Updates**:
  - Modified the settings pane in `MainView.axaml` to include a new checkbox for "Use TLS." Adjusted row indices for existing settings to accommodate the new field. (`src/UI/Views/MainView.axaml` [[1]](diffhunk://#diff-cab8a3bdcb543f2cc6d56ddc5465c06696d3b70e7f0bb75c332d0a3e0dea063bL242-R242) [[2]](diffhunk://#diff-cab8a3bdcb543f2cc6d56ddc5465c06696d3b70e7f0bb75c332d0a3e0dea063bR274-R329)

### Command Handling Enhancements

* **Command Parsing and Dispatching**:
  - Updated the `CommandParserService` to parse the `:setusetls` command and validate its arguments. (`src/Businesslogic/Services/CommandParserService.cs` [src/Businesslogic/Services/CommandParserService.csR289-R300](diffhunk://#diff-36e9c5fa751c2134a8acc2d6c98cb98f84460d7fe34cabaacc9ac87b8a14a720R289-R300))
  - Enhanced the `DispatchCommand` method in `MainViewModel` to handle the `SetUseTls` command, updating the `UseTls` setting and providing feedback via the status bar. (`src/UI/ViewModels/MainViewModel.cs` [[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR1104-R1125) [[2]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR1160)

These changes collectively enable TLS configuration for MQTT connections, ensuring users can easily control encryption settings through commands, settings, and the user interface.