### PR TITLE
Add visual expiry indication for MQTT messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Whether you're a seasoned developer or a newcomer to IoT, Crow’s NestMQTT prov
     * metadata like `response-topic`, `correlation-data`, `content-type`  etc.
     * all user properties
   * Supports MQTT V5 enhanced authentication
+  * Visual indication of expired messages ⏰
+    * Strikethrough and dimmed text in message history for expired messages
+    * Yellow warning icon in metadata view for the expiry field
 * Supports TLS connection to MQTT Broker 🔐
 * Can handle huge amount of MQTT messages 
 * Allows filtering of MQTT topics by pattern 🗃️
@@ -52,7 +55,7 @@ Shows the history of received messages of the selected topic. Including the rece
 Shows the payload of the message selected in history view. Supports rendering of JSON payload or shows payload as text. The default viewer is depending on `content-type` of the selected Message. The viewer can be switched by using `:view raw`, `:view json` and `:view image` commands.
 
 **6. Metadata View**
-Shows all the metadata of the message selected in history view. Including standard metadata like `correlation-id`, `response-topic` but also custom metadata like `user-properties`. 
+Shows all the metadata of the message selected in history view. Including standard metadata like `correlation-id`, `response-topic` but also custom metadata like `user-properties`. When a message has a non-zero `message-expiry-interval`, the metadata view shows the remaining time or "EXPIRED" status. Expired messages display a yellow warning icon next to the expiry field.
 
 ### Settings
 **1. Connection Settings**  
@@ -112,6 +115,8 @@ Crow's NestMQTT understand MQTT V5 request/response, each request message shows 
 
 Once the response message is received (first message send to given response topic that has the same correlation data), and clickable arrow icon allows jumping direct to the response.
 ![](./doc/images/go-to-response.png)
+
+Messages with MQTT V5 `message-expiry-interval` are visually marked when they expire: the message history shows them with strikethrough text and dimmed foreground, while the metadata view displays a yellow warning triangle icon next to the expiry field with the "EXPIRED" status.
 
 ## Command Interface
 

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -80,6 +80,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     private readonly Queue<IdentifiedMqttApplicationMessageReceivedEventArgs> _pendingMessages = new();
     private readonly object _batchLock = new object();
     private Timer? _batchProcessingTimer;
+    private Timer? _expiryRefreshTimer;
     private readonly IScheduler _uiScheduler;
     private readonly bool _testMode; // Added: detect test/CI mode to disable expensive background infra
     // Per-topic message storage (prevents cross-topic eviction)
@@ -1329,7 +1330,8 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             this,
             e.ApplicationMessage,
             true, // enableFallbackFullMessage
-            e.IsEffectivelyRetained);
+            e.IsEffectivelyRetained,
+            e.ApplicationMessage.MessageExpiryInterval);
 
         messageViewModels.Add(messageVm);
 
@@ -1402,6 +1404,12 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         if (addedVmList.Count > 0)
         {
             _messageHistorySource.AddRange(addedVmList);
+
+            // Start expiry timer if any added messages have expiry intervals
+            if (addedVmList.Any(m => m.HasExpiry))
+            {
+                EnsureExpiryTimerRunning();
+            }
 
             // In test mode, manually update the simple filtered collection
             if (_testMode)
@@ -1789,7 +1797,37 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         var retainStatus = messageVm?.IsEffectivelyRetained.ToString() ?? msg.Retain.ToString();
         MessageMetadata.Add(new MetadataItem("Retain", retainStatus));
         MessageMetadata.Add(new MetadataItem("Payload Format", msg.PayloadFormatIndicator.ToString()));
-        MessageMetadata.Add(new MetadataItem("Expiry (s)", msg.MessageExpiryInterval.ToString()));
+
+        // Show computed expiry status with warning icon if expired
+        if (msg.MessageExpiryInterval > 0 && messageVm != null)
+        {
+            var remaining = messageVm.TimeRemaining;
+            string expiryText;
+            WarningIconViewModel? warningIcon = null;
+            if (messageVm.IsExpired)
+            {
+                expiryText = $"{msg.MessageExpiryInterval}s (EXPIRED)";
+                warningIcon = new WarningIconViewModel
+                {
+                    IsVisible = true,
+                    ToolTip = "This message has expired"
+                };
+            }
+            else if (remaining.HasValue)
+            {
+                expiryText = $"{msg.MessageExpiryInterval}s ({remaining.Value.TotalSeconds:F0}s remaining)";
+            }
+            else
+            {
+                expiryText = msg.MessageExpiryInterval.ToString();
+            }
+            MessageMetadata.Add(new MetadataItem("Expiry (s)", expiryText, warningIconViewModel: warningIcon));
+        }
+        else
+        {
+            MessageMetadata.Add(new MetadataItem("Expiry (s)", msg.MessageExpiryInterval.ToString()));
+        }
+
         MessageMetadata.Add(new MetadataItem("ContentType", msg.ContentType));
 
         // Add Response Topic with icon if present
@@ -2263,6 +2301,62 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         Log.Debug("Stopping UI update timer.");
         _updateTimer?.Dispose();
         _updateTimer = null;
+    }
+
+    /// <summary>
+    /// Ensures the shared expiry refresh timer is running.
+    /// Called when messages with non-zero MessageExpiryInterval are added.
+    /// </summary>
+    private void EnsureExpiryTimerRunning()
+    {
+        if (_expiryRefreshTimer != null || _testMode) return;
+        _expiryRefreshTimer = new Timer(ExpiryRefreshTick, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    /// Called every second to refresh expiry state on all messages that have an expiry interval.
+    /// </summary>
+    private void ExpiryRefreshTick(object? state)
+    {
+        if (_disposedValue) return;
+        try
+        {
+            var messagesWithExpiry = _messageHistorySource.Items
+                .Where(m => m.HasExpiry)
+                .ToList();
+
+            if (messagesWithExpiry.Count == 0)
+            {
+                // No messages with expiry, stop the timer
+                _expiryRefreshTimer?.Dispose();
+                _expiryRefreshTimer = null;
+                return;
+            }
+
+            var selectedMsg = SelectedMessage;
+            bool selectedWasExpired = selectedMsg?.IsExpired ?? false;
+
+            foreach (var msg in messagesWithExpiry)
+            {
+                msg.RefreshExpiry();
+            }
+
+            // If the selected message's expiry state changed, refresh the metadata table
+            if (selectedMsg != null && selectedMsg.HasExpiry && selectedMsg.IsExpired != selectedWasExpired)
+            {
+                _syncContext?.Post(_ =>
+                {
+                    if (SelectedMessage == selectedMsg)
+                    {
+                        UpdateMessageDetails(selectedMsg);
+                    }
+                }, null);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error during expiry refresh tick");
+        }
     }
 
     /// <summary>
@@ -4042,6 +4136,8 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
 
                 _uiHeartbeatTimer?.Dispose();
                 _uiHeartbeatTimer = null;
+                _expiryRefreshTimer?.Dispose();
+                _expiryRefreshTimer = null;
                 // Dispose managed state (managed objects).
                 Log.Debug("Disposing MainViewModel resources...");
                 if (!_cts.IsCancellationRequested)

--- a/src/UI/ViewModels/MessageViewModel.cs
+++ b/src/UI/ViewModels/MessageViewModel.cs
@@ -13,6 +13,7 @@ public class MessageViewModel : ReactiveObject
     private readonly IStatusBarService _statusBarService;
     private readonly bool _enableFallback;
     private MqttApplicationMessage? _cachedMessage;
+    private bool _isExpired;
 
     public Guid MessageId { get; }
     public string Topic { get; }
@@ -20,6 +21,41 @@ public class MessageViewModel : ReactiveObject
     public string PayloadPreview { get; } = string.Empty; // Store the generated preview (initialized for nullable safety)
     public int Size { get; }
     public bool IsEffectivelyRetained { get; } // Store the corrected retain status
+
+    /// <summary>
+    /// The MQTT 5 message expiry interval in seconds. 0 means no expiry.
+    /// </summary>
+    public uint MessageExpiryInterval { get; }
+
+    /// <summary>
+    /// Whether this message has expired based on its timestamp and expiry interval.
+    /// Updated by the shared expiry timer in MainViewModel.
+    /// </summary>
+    public bool IsExpired
+    {
+        get => _isExpired;
+        private set => this.RaiseAndSetIfChanged(ref _isExpired, value);
+    }
+
+    /// <summary>
+    /// True when the message has a non-zero expiry interval.
+    /// </summary>
+    public bool HasExpiry => MessageExpiryInterval > 0;
+
+    /// <summary>
+    /// Returns the remaining time before expiry, or null if no expiry is set.
+    /// Returns TimeSpan.Zero if already expired.
+    /// </summary>
+    public TimeSpan? TimeRemaining
+    {
+        get
+        {
+            if (!HasExpiry) return null;
+            var expiresAt = Timestamp.Add(TimeSpan.FromSeconds(MessageExpiryInterval));
+            var remaining = expiresAt - DateTime.Now;
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+    }
 
     // Display text remains the same, based on stored preview
     public string DisplayText => $"{Timestamp:HH:mm:ss.fff} ({Size,10} B): {PayloadPreview}";
@@ -35,7 +71,8 @@ public class MessageViewModel : ReactiveObject
         IStatusBarService statusBarService,
         MqttApplicationMessage? fullMessage = null,
         bool enableFallbackFullMessage = true,
-        bool isEffectivelyRetained = false)
+        bool isEffectivelyRetained = false,
+        uint messageExpiryInterval = 0)
     {
         MessageId = messageId;
         Topic = topic ?? throw new ArgumentNullException(nameof(topic));
@@ -43,10 +80,26 @@ public class MessageViewModel : ReactiveObject
         PayloadPreview = payloadPreview ?? string.Empty;
         Size = size;
         IsEffectivelyRetained = isEffectivelyRetained;
+        MessageExpiryInterval = messageExpiryInterval;
         _mqttService = mqttService ?? throw new ArgumentNullException(nameof(mqttService));
         _statusBarService = statusBarService ?? throw new ArgumentNullException(nameof(statusBarService));
         _cachedMessage = fullMessage;
         _enableFallback = enableFallbackFullMessage;
+
+        // Compute initial expiry state
+        if (HasExpiry)
+        {
+            _isExpired = DateTime.Now > Timestamp.Add(TimeSpan.FromSeconds(MessageExpiryInterval));
+        }
+    }
+
+    /// <summary>
+    /// Re-evaluates the expiry state. Called by the shared timer in MainViewModel.
+    /// </summary>
+    public void RefreshExpiry()
+    {
+        if (!HasExpiry) return;
+        IsExpired = DateTime.Now > Timestamp.Add(TimeSpan.FromSeconds(MessageExpiryInterval));
     }
 
     // Method to be called when details are requested (e.g., on selection)

--- a/src/UI/ViewModels/MetadataItem.cs
+++ b/src/UI/ViewModels/MetadataItem.cs
@@ -7,6 +7,7 @@ namespace CrowsNestMqtt.UI.ViewModels;
 public class MetadataItem : ReactiveObject
 {
     private ResponseIconViewModel? _iconViewModel;
+    private WarningIconViewModel? _warningIconViewModel;
 
     public string Key { get; init; } = string.Empty;
     public string Value { get; init; } = string.Empty;
@@ -21,15 +22,30 @@ public class MetadataItem : ReactiveObject
     }
 
     /// <summary>
+    /// Optional warning icon view model for metadata items that need a warning indicator (e.g., expired messages)
+    /// </summary>
+    public WarningIconViewModel? WarningIconViewModel
+    {
+        get => _warningIconViewModel;
+        set => this.RaiseAndSetIfChanged(ref _warningIconViewModel, value);
+    }
+
+    /// <summary>
     /// Indicates if this metadata item should show an icon
     /// </summary>
     public bool HasIcon => IconViewModel != null && IconViewModel.IsVisible;
 
-    public MetadataItem(string key, string value, ResponseIconViewModel? iconViewModel = null)
+    /// <summary>
+    /// Indicates if this metadata item should show a warning icon
+    /// </summary>
+    public bool HasWarningIcon => WarningIconViewModel != null && WarningIconViewModel.IsVisible;
+
+    public MetadataItem(string key, string value, ResponseIconViewModel? iconViewModel = null, WarningIconViewModel? warningIconViewModel = null)
     {
         Key = key;
         Value = value;
         IconViewModel = iconViewModel;
+        WarningIconViewModel = warningIconViewModel;
     }
 
     public override bool Equals(object? obj)
@@ -106,4 +122,25 @@ public class ResponseIconViewModel : ReactiveObject
 
     public string? NavigationCommand { get; set; }
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// View model for warning icons in metadata items (e.g., expired message indicator)
+/// </summary>
+public class WarningIconViewModel : ReactiveObject
+{
+    private string _toolTip = string.Empty;
+    private bool _isVisible = true;
+
+    public string ToolTip
+    {
+        get => _toolTip;
+        set => this.RaiseAndSetIfChanged(ref _toolTip, value);
+    }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => this.RaiseAndSetIfChanged(ref _isVisible, value);
+    }
 }

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -24,6 +24,8 @@
     <!-- Response status icons -->
     <StreamGeometry x:Key="clock_icon">M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z</StreamGeometry>
     <StreamGeometry x:Key="arrow_icon">M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z</StreamGeometry>
+    <!-- Warning icon for expired messages -->
+    <StreamGeometry x:Key="warning_icon">M12 2L1 21h22L12 2zm0 3.99L19.53 19H4.47L12 5.99zM11 16h2v2h-2v-2zm0-6h2v4h-2v-4z</StreamGeometry>
   </UserControl.Resources>
 
  <Design.DataContext>
@@ -264,6 +266,19 @@
                                       </DataTemplate>
                                   </DataGridTemplateColumn.CellTemplate>
                               </DataGridTemplateColumn>
+                              <!-- Warning icon column for expired messages -->
+                              <DataGridTemplateColumn Header="" Width="Auto">
+                                  <DataGridTemplateColumn.CellTemplate>
+                                      <DataTemplate DataType="{x:Type vm:MetadataItem}">
+                                          <Panel IsVisible="{Binding HasWarningIcon}">
+                                              <PathIcon Width="16" Height="16"
+                                                        Data="{StaticResource warning_icon}"
+                                                        Foreground="#DAA520"
+                                                        ToolTip.Tip="{Binding WarningIconViewModel.ToolTip}"/>
+                                          </Panel>
+                                      </DataTemplate>
+                                  </DataGridTemplateColumn.CellTemplate>
+                              </DataGridTemplateColumn>
                           </DataGrid.Columns>
                       </DataGrid>
 
@@ -392,7 +407,15 @@
                                 <!-- DisplayText (Fills remaining space) -->
                                 <TextBlock Text="{Binding DisplayText}"
                                            TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           Classes.Expired="{Binding IsExpired}">
+                                    <TextBlock.Styles>
+                                        <Style Selector="TextBlock.Expired">
+                                            <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                            <Setter Property="Foreground" Value="Gray"/>
+                                        </Style>
+                                    </TextBlock.Styles>
+                                </TextBlock>
                              </DockPanel>
                          </DataTemplate>
                      </ListBox.ItemTemplate>

--- a/tests/UnitTests/ViewModels/MessageDisplayTests.cs
+++ b/tests/UnitTests/ViewModels/MessageDisplayTests.cs
@@ -353,5 +353,109 @@ namespace CrowsNestMqtt.UnitTests.ViewModels
             Assert.Equal("temperature", temperatureNode.Name);
             Assert.Equal(2, temperatureNode.Children.Count); // living-room and kitchen
         }
+
+        [Fact]
+        public void UpdateMessageDetails_WithExpiredMessage_ShouldShowExpiredMetadata()
+        {
+            // Arrange
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, uiScheduler: Scheduler.Immediate);
+            var messageId = Guid.NewGuid();
+            var pastTimestamp = DateTime.Now.AddSeconds(-60);
+            var topic = "test/expiry";
+            var payload = "expiring payload";
+            var fullMessage = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(Encoding.UTF8.GetBytes(payload))
+                .WithMessageExpiryInterval(30) // 30s expiry, but message is 60s old
+                .Build();
+
+            _mqttServiceMock.TryGetMessage(topic, messageId, out Arg.Any<MqttApplicationMessage?>())
+                .Returns(x => {
+                    x[2] = fullMessage;
+                    return true;
+                });
+
+            var testMessage = new MessageViewModel(messageId, topic, pastTimestamp, payload,
+                Encoding.UTF8.GetBytes(payload).Length, _mqttServiceMock, _statusBarServiceMock, fullMessage,
+                messageExpiryInterval: 30);
+
+            // Act
+            viewModel.SelectedMessage = testMessage;
+
+            // Assert
+            var expiryItem = viewModel.MessageMetadata.FirstOrDefault(m => m.Key == "Expiry (s)");
+            Assert.NotNull(expiryItem);
+            Assert.Contains("EXPIRED", expiryItem.Value);
+            Assert.NotNull(expiryItem.WarningIconViewModel);
+            Assert.True(expiryItem.HasWarningIcon);
+        }
+
+        [Fact]
+        public void UpdateMessageDetails_WithActiveExpiryMessage_ShouldShowRemainingTime()
+        {
+            // Arrange
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, uiScheduler: Scheduler.Immediate);
+            var messageId = Guid.NewGuid();
+            var timestamp = DateTime.Now;
+            var topic = "test/expiry";
+            var payload = "active expiry payload";
+            var fullMessage = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(Encoding.UTF8.GetBytes(payload))
+                .WithMessageExpiryInterval(3600) // 1 hour expiry
+                .Build();
+
+            _mqttServiceMock.TryGetMessage(topic, messageId, out Arg.Any<MqttApplicationMessage?>())
+                .Returns(x => {
+                    x[2] = fullMessage;
+                    return true;
+                });
+
+            var testMessage = new MessageViewModel(messageId, topic, timestamp, payload,
+                Encoding.UTF8.GetBytes(payload).Length, _mqttServiceMock, _statusBarServiceMock, fullMessage,
+                messageExpiryInterval: 3600);
+
+            // Act
+            viewModel.SelectedMessage = testMessage;
+
+            // Assert
+            var expiryItem = viewModel.MessageMetadata.FirstOrDefault(m => m.Key == "Expiry (s)");
+            Assert.NotNull(expiryItem);
+            Assert.Contains("remaining", expiryItem.Value);
+            Assert.Null(expiryItem.WarningIconViewModel);
+        }
+
+        [Fact]
+        public void UpdateMessageDetails_WithZeroExpiry_ShouldShowZero()
+        {
+            // Arrange
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, uiScheduler: Scheduler.Immediate);
+            var messageId = Guid.NewGuid();
+            var timestamp = DateTime.Now;
+            var topic = "test/noexpiry";
+            var payload = "no expiry payload";
+            var fullMessage = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(Encoding.UTF8.GetBytes(payload))
+                .Build(); // No expiry interval set (defaults to 0)
+
+            _mqttServiceMock.TryGetMessage(topic, messageId, out Arg.Any<MqttApplicationMessage?>())
+                .Returns(x => {
+                    x[2] = fullMessage;
+                    return true;
+                });
+
+            var testMessage = new MessageViewModel(messageId, topic, timestamp, payload,
+                Encoding.UTF8.GetBytes(payload).Length, _mqttServiceMock, _statusBarServiceMock, fullMessage);
+
+            // Act
+            viewModel.SelectedMessage = testMessage;
+
+            // Assert
+            var expiryItem = viewModel.MessageMetadata.FirstOrDefault(m => m.Key == "Expiry (s)");
+            Assert.NotNull(expiryItem);
+            Assert.Equal("0", expiryItem.Value);
+            Assert.Null(expiryItem.WarningIconViewModel);
+        }
     }
 }

--- a/tests/UnitTests/ViewModels/MessageExpiryTests.cs
+++ b/tests/UnitTests/ViewModels/MessageExpiryTests.cs
@@ -1,0 +1,173 @@
+using System;
+using Xunit;
+using MQTTnet;
+using NSubstitute;
+using CrowsNestMqtt.UI.ViewModels;
+using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.UI.Services;
+
+namespace UnitTests.ViewModels
+{
+    public class MessageExpiryTests
+    {
+        private readonly IMqttService _mqttServiceMock;
+        private readonly IStatusBarService _statusBarServiceMock;
+
+        public MessageExpiryTests()
+        {
+            _mqttServiceMock = Substitute.For<IMqttService>();
+            _statusBarServiceMock = Substitute.For<IStatusBarService>();
+        }
+
+        [Fact]
+        public void IsExpired_WhenExpiryIntervalIsZero_ShouldReturnFalse()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 0);
+
+            Assert.False(vm.IsExpired);
+            Assert.False(vm.HasExpiry);
+        }
+
+        [Fact]
+        public void IsExpired_WhenMessageIsWithinExpiryWindow_ShouldReturnFalse()
+        {
+            // Message created now with 3600s (1 hour) expiry - should not be expired
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 3600);
+
+            Assert.True(vm.HasExpiry);
+            Assert.False(vm.IsExpired);
+        }
+
+        [Fact]
+        public void IsExpired_WhenMessageHasExpired_ShouldReturnTrue()
+        {
+            // Message created 10 seconds ago with 5s expiry - should be expired
+            var pastTimestamp = DateTime.Now.AddSeconds(-10);
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", pastTimestamp, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 5);
+
+            Assert.True(vm.HasExpiry);
+            Assert.True(vm.IsExpired);
+        }
+
+        [Fact]
+        public void TimeRemaining_WhenNoExpiry_ShouldReturnNull()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 0);
+
+            Assert.Null(vm.TimeRemaining);
+        }
+
+        [Fact]
+        public void TimeRemaining_WhenExpired_ShouldReturnZero()
+        {
+            var pastTimestamp = DateTime.Now.AddSeconds(-10);
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", pastTimestamp, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 5);
+
+            Assert.Equal(TimeSpan.Zero, vm.TimeRemaining);
+        }
+
+        [Fact]
+        public void TimeRemaining_WhenNotExpired_ShouldReturnPositiveValue()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 3600);
+
+            var remaining = vm.TimeRemaining;
+            Assert.NotNull(remaining);
+            Assert.True(remaining.Value > TimeSpan.Zero);
+            Assert.True(remaining.Value <= TimeSpan.FromSeconds(3600));
+        }
+
+        [Fact]
+        public void RefreshExpiry_WhenMessageExpires_ShouldUpdateIsExpired()
+        {
+            // Message created 4 seconds ago with 2s expiry - already expired
+            var pastTimestamp = DateTime.Now.AddSeconds(-4);
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", pastTimestamp, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 2);
+
+            vm.RefreshExpiry();
+
+            Assert.True(vm.IsExpired);
+        }
+
+        [Fact]
+        public void RefreshExpiry_WhenNoExpiry_ShouldNotChangeState()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 0);
+
+            vm.RefreshExpiry();
+
+            Assert.False(vm.IsExpired);
+        }
+
+        [Fact]
+        public void DisplayText_ShouldWorkCorrectlyRegardlessOfExpiry()
+        {
+            var timestamp = DateTime.Now;
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", timestamp, "test payload", 12,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 5);
+
+            var expected = $"{timestamp:HH:mm:ss.fff} ({12,10} B): test payload";
+            Assert.Equal(expected, vm.DisplayText);
+        }
+
+        [Fact]
+        public void HasExpiry_WhenIntervalGreaterThanZero_ShouldReturnTrue()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 1);
+
+            Assert.True(vm.HasExpiry);
+        }
+
+        [Fact]
+        public void MessageExpiryInterval_ShouldBeStoredCorrectly()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock,
+                messageExpiryInterval: 42);
+
+            Assert.Equal(42u, vm.MessageExpiryInterval);
+        }
+
+        [Fact]
+        public void Constructor_DefaultExpiryInterval_ShouldBeZero()
+        {
+            var vm = new MessageViewModel(
+                Guid.NewGuid(), "test/topic", DateTime.Now, "payload", 7,
+                _mqttServiceMock, _statusBarServiceMock);
+
+            Assert.Equal(0u, vm.MessageExpiryInterval);
+            Assert.False(vm.HasExpiry);
+            Assert.False(vm.IsExpired);
+        }
+    }
+}

--- a/tests/UnitTests/ViewModels/MetadataItemTests.cs
+++ b/tests/UnitTests/ViewModels/MetadataItemTests.cs
@@ -411,5 +411,46 @@ namespace UnitTests.ViewModels
             var vm = new ResponseIconViewModel { RequestMessageId = "msg-456" };
             Assert.Equal("msg-456", vm.RequestMessageId);
         }
+
+        [Fact]
+        public void Constructor_WithWarningIconViewModel_SetsWarningIcon()
+        {
+            var warningVm = new WarningIconViewModel
+            {
+                IsVisible = true,
+                ToolTip = "This message has expired"
+            };
+
+            var item = new MetadataItem("Expiry (s)", "30s (EXPIRED)", warningIconViewModel: warningVm);
+            Assert.True(item.HasWarningIcon);
+            Assert.NotNull(item.WarningIconViewModel);
+            Assert.Equal("This message has expired", item.WarningIconViewModel!.ToolTip);
+        }
+
+        [Fact]
+        public void HasWarningIcon_WhenNoWarningViewModel_ReturnsFalse()
+        {
+            var item = new MetadataItem("Key", "Value");
+            Assert.False(item.HasWarningIcon);
+            Assert.Null(item.WarningIconViewModel);
+        }
+
+        [Fact]
+        public void HasWarningIcon_WhenWarningViewModelNotVisible_ReturnsFalse()
+        {
+            var warningVm = new WarningIconViewModel { IsVisible = false };
+            var item = new MetadataItem("Key", "Value", warningIconViewModel: warningVm);
+            Assert.False(item.HasWarningIcon);
+        }
+
+        [Fact]
+        public void WarningIconViewModel_ToolTip_CanBeChanged()
+        {
+            var warningVm = new WarningIconViewModel { ToolTip = "Initial" };
+            Assert.Equal("Initial", warningVm.ToolTip);
+
+            warningVm.ToolTip = "Updated";
+            Assert.Equal("Updated", warningVm.ToolTip);
+        }
     }
 }

--- a/tools/SendTestData.ps1
+++ b/tools/SendTestData.ps1
@@ -372,6 +372,26 @@ Write-Host "  - sender: SendTestData.ps1"
 Write-Host "  - version: 1.0.0"
 Write-Host ""
 
+# --- Messages with Message Expiry Interval ---
+
+$expiryIntervals = @(5, 30, 90)
+foreach ($interval in $expiryIntervals) {
+    $expiryMsgBuilder = [MQTTnet.MqttApplicationMessageBuilder]::new()
+    $expiryMsgBuilder = $expiryMsgBuilder.WithTopic("test/expiry/${interval}s")
+    $expiryMsgBuilder = $expiryMsgBuilder.WithPayload([byte[]]::new(0))
+    $expiryMsgBuilder = $expiryMsgBuilder.WithQualityOfServiceLevel([MQTTnet.Protocol.MqttQualityOfServiceLevel]::AtLeastOnce)
+    $expiryMsgBuilder = $expiryMsgBuilder.WithMessageExpiryInterval($interval)
+    $expiryMessage = $expiryMsgBuilder.Build()
+
+    Send-MqttMessage -Message $expiryMessage -Description "Expiring message sent to topic 'test/expiry/${interval}s' with empty payload and ${interval}s expiry interval."
+}
+
+Write-Host ""
+Write-Host "=== Message Expiry Summary ==="
+Write-Host "Sent 3 messages with expiry intervals: 5s, 30s, 90s"
+Write-Host "These messages will visually expire in the Crow's NestMQTT UI with strikethrough and warning icons."
+Write-Host ""
+
 # Disconnect
 if ($client.IsConnected) {
     $opts = [MQTTnet.MqttClientDisconnectOptions]::new()


### PR DESCRIPTION
 Show expired messages with strikethrough and dimmed text in the message history list. Display a yellow warning icon next to the expiry metadata field. Compute and show live countdown (e.g. "30s (15s remaining)") or  "EXPIRED" status that auto-refreshes via a shared 1-second timer.

 - Add IsExpired, HasExpiry, TimeRemaining properties to MessageViewModel
 - Add WarningIconViewModel to MetadataItem for expiry warning icon
 - Add shared expiry refresh timer in MainViewModel with metadata refresh
 - Add strikethrough/dimmed styling and warning icon in MainView.axaml
 - Extend SendTestData.ps1 with 3 expiring test messages (5s, 30s, 90s)
 - Add 17 unit tests covering expiry logic, metadata display, warning icon
 - Update README.md with expiry indication feature documentation

Closes #128 