### PR TITLE
Optimized JSON rendering

### DIFF
--- a/src/UI/ViewModels/JsonNodeViewModel.cs
+++ b/src/UI/ViewModels/JsonNodeViewModel.cs
@@ -10,6 +10,15 @@ namespace CrowsNestMqtt.UI.ViewModels;
 /// </summary>
 public class JsonNodeViewModel : ReactiveObject
 {
+    /// <summary>
+    /// Maximum number of characters to display for string / fallback values in
+    /// the TreeView. Long strings (e.g. embedded base64 blobs or multi-KB text
+    /// inside JSON payloads) are truncated with an ellipsis suffix to keep the
+    /// TreeView responsive; the original value is still available via the
+    /// underlying raw payload views.
+    /// </summary>
+    public const int MaxValueDisplayLength = 500;
+
     public string Name { get; }
     public string ValueDisplay { get; }
     public JsonValueKind ValueKind { get; }
@@ -50,13 +59,34 @@ public class JsonNodeViewModel : ReactiveObject
         {
             JsonValueKind.Object => "{...}", // Placeholder for objects
             JsonValueKind.Array => $"[...] ({element.GetArrayLength()})", // Placeholder for arrays showing count
-            JsonValueKind.String => $"\"{element.GetString()}\"", // Add quotes for strings
+            JsonValueKind.String => FormatString(element.GetString()),
             JsonValueKind.Number => element.GetRawText(),
             JsonValueKind.True => "true",
             JsonValueKind.False => "false",
             JsonValueKind.Null => "null",
-            _ => element.ToString() // Fallback
+            _ => Truncate(element.ToString()) // Fallback
         };
+    }
+
+    private static string FormatString(string? value)
+    {
+        if (value == null) return "\"\"";
+        if (value.Length <= MaxValueDisplayLength)
+        {
+            return $"\"{value}\"";
+        }
+        // Truncate + ellipsis marker + original length hint. Keep quoting to
+        // match the non-truncated rendering convention.
+        return $"\"{value.Substring(0, MaxValueDisplayLength)}…\" ({value.Length} chars)";
+    }
+
+    private static string Truncate(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= MaxValueDisplayLength)
+        {
+            return value;
+        }
+        return value.Substring(0, MaxValueDisplayLength) + "…";
     }
 
     private IBrush GetValueBrush(JsonValueKind kind)

--- a/src/UI/ViewModels/JsonViewerViewModel.cs
+++ b/src/UI/ViewModels/JsonViewerViewModel.cs
@@ -11,6 +11,20 @@ namespace CrowsNestMqtt.UI.ViewModels;
 /// </summary>
 public class JsonViewerViewModel : ReactiveObject
 {
+    /// <summary>
+    /// Maximum depth at which nodes are auto-expanded (1-based).
+    /// </summary>
+    public const int AutoExpandMaxDepth = 5;
+
+    /// <summary>
+    /// Maximum total descendant node count for a subtree to be auto-expanded.
+    /// Subtrees whose descendant count exceeds this budget remain collapsed on load,
+    /// preventing the TreeView from materializing thousands of visuals synchronously
+    /// when a large / deeply-nested JSON payload is displayed.
+    /// The user can still click to expand these subtrees manually.
+    /// </summary>
+    public const int AutoExpandNodeBudget = 500;
+
     private string _jsonParseError = string.Empty;
     public string JsonParseError
     {
@@ -63,11 +77,13 @@ public JsonNodeViewModel? SelectedNode
             {
                 // Create a single root node for the array itself
                 var arrayRootNode = new JsonNodeViewModel("$", jsonDoc.RootElement, "$") { Depth = 0 };
-                // Set expansion based on depth (depth 0, so always expanded)
-                arrayRootNode.IsExpanded = true;
                 RootNodes.Add(arrayRootNode);
                 // Populate the children of this array node (depth 1)
-                PopulateNodes(jsonDoc.RootElement, arrayRootNode.Children, arrayRootNode.JsonPath, 1);
+                var arraySubtreeCount = PopulateNodes(jsonDoc.RootElement, arrayRootNode.Children, arrayRootNode.JsonPath, 1);
+                // The array-root itself is at depth 0 (always within AutoExpandMaxDepth),
+                // but still guard against auto-expanding huge arrays that would force the
+                // TreeView to materialize thousands of items synchronously.
+                arrayRootNode.IsExpanded = arraySubtreeCount <= AutoExpandNodeBudget;
             }
             else
             {
@@ -89,26 +105,52 @@ public JsonNodeViewModel? SelectedNode
         }
     }
 
-    private void PopulateNodes(JsonElement element, ObservableCollection<JsonNodeViewModel> children, string currentPath, int depth)
+    /// <summary>
+    /// Recursively materializes JsonNodeViewModels for the given element and returns
+    /// the total count of descendant nodes produced (excluding the elements added
+    /// into <paramref name="children"/> themselves? -- see remarks).
+    /// </summary>
+    /// <remarks>
+    /// Returned value is the total number of JsonNodeViewModel instances appended
+    /// to <paramref name="children"/> (including transitive grandchildren). It is
+    /// used to decide whether a container node is cheap enough to auto-expand
+    /// (see <see cref="AutoExpandNodeBudget"/>). The rule applied to each container
+    /// child is: expand when <c>depth &lt;= AutoExpandMaxDepth</c> AND the container's
+    /// own descendant count fits the budget. This keeps the familiar depth-based UX
+    /// for small JSON payloads while preventing the TreeView from synchronously
+    /// materializing thousands of TreeViewItems for large / deeply-nested payloads.
+    /// </remarks>
+    private int PopulateNodes(JsonElement element, ObservableCollection<JsonNodeViewModel> children, string currentPath, int depth)
     {
+        int totalAdded = 0;
         switch (element.ValueKind)
         {
             case JsonValueKind.Object:
                 foreach (var property in element.EnumerateObject())
                 {
-                    // Use property name escaping if needed for complex keys
-                    string safeName = property.Name; // Basic for now
-                    string childPath = $"{currentPath}.{safeName}"; // Basic path construction
+                    string safeName = property.Name;
+                    string childPath = $"{currentPath}.{safeName}";
                     var node = new JsonNodeViewModel(property.Name, property.Value, childPath) { Depth = depth };
 
-                    // FR-008: Auto-expand up to depth 5
-                    node.IsExpanded = depth <= 5 && (property.Value.ValueKind == JsonValueKind.Object || property.Value.ValueKind == JsonValueKind.Array);
-
                     children.Add(node);
-                    // Recursively populate children if it's an object or array
-                    if (property.Value.ValueKind == JsonValueKind.Object || property.Value.ValueKind == JsonValueKind.Array)
+                    totalAdded++;
+
+                    bool isContainer = property.Value.ValueKind == JsonValueKind.Object
+                                       || property.Value.ValueKind == JsonValueKind.Array;
+                    if (isContainer)
                     {
-                        PopulateNodes(property.Value, node.Children, node.JsonPath, depth + 1);
+                        int descendantCount = PopulateNodes(property.Value, node.Children, node.JsonPath, depth + 1);
+                        totalAdded += descendantCount;
+
+                        // FR-008: Auto-expand up to depth 5, but only if the subtree
+                        // is small enough to render cheaply. Larger subtrees stay
+                        // collapsed on load and the user can expand them manually.
+                        node.IsExpanded = depth <= AutoExpandMaxDepth
+                                          && descendantCount <= AutoExpandNodeBudget;
+                    }
+                    else
+                    {
+                        node.IsExpanded = false;
                     }
                 }
                 break;
@@ -120,14 +162,22 @@ public JsonNodeViewModel? SelectedNode
                     string childPath = $"{currentPath}[{index}]";
                     var node = new JsonNodeViewModel($"[{index}]", item, childPath) { Depth = depth };
 
-                    // FR-008: Auto-expand up to depth 5
-                    node.IsExpanded = depth <= 5 && (item.ValueKind == JsonValueKind.Object || item.ValueKind == JsonValueKind.Array);
-
                     children.Add(node);
-                    // Recursively populate children if it's an object or array
-                    if (item.ValueKind == JsonValueKind.Object || item.ValueKind == JsonValueKind.Array)
+                    totalAdded++;
+
+                    bool isContainer = item.ValueKind == JsonValueKind.Object
+                                       || item.ValueKind == JsonValueKind.Array;
+                    if (isContainer)
                     {
-                        PopulateNodes(item, node.Children, node.JsonPath, depth + 1);
+                        int descendantCount = PopulateNodes(item, node.Children, node.JsonPath, depth + 1);
+                        totalAdded += descendantCount;
+
+                        node.IsExpanded = depth <= AutoExpandMaxDepth
+                                          && descendantCount <= AutoExpandNodeBudget;
+                    }
+                    else
+                    {
+                        node.IsExpanded = false;
                     }
                     index++;
                 }
@@ -138,6 +188,7 @@ public JsonNodeViewModel? SelectedNode
                  AppLogger.Warning("Unexpected JsonValueKind encountered directly in PopulateNodes: {ValueKind}", element.ValueKind);
                  break;
         }
+        return totalAdded;
     }
 
     // Helper to get string representation consistent with JsonNodeViewModel display

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -2077,6 +2077,23 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         }
         if (isPayloadValidUtf8)
         {
+            // Safety guard: very large payloads without an explicit application/json
+            // content-type are unlikely to be JSON and can freeze the UI while the
+            // TreeView attempts to render thousands of nodes. Fall back to the raw
+            // viewer and let the user request the JSON tree explicitly via :view json.
+            const int JsonAutoViewMaxLength = 2 * 1024 * 1024; // 2 MB of UTF-16 chars
+            bool isExplicitJsonContentType = msg.ContentType != null
+                && msg.ContentType.Contains("json", StringComparison.OrdinalIgnoreCase);
+            if (payloadAsString.Length > JsonAutoViewMaxLength && !isExplicitJsonContentType)
+            {
+                ShowRawPayload(isPayloadValidUtf8, payloadAsString, msg);
+                StatusBarText = $"Payload too large ({payloadAsString.Length:N0} chars) for automatic JSON tree view. Showing raw. Use :view json to force.";
+                Log.Information("Skipped automatic JSON tree view for oversized payload ({Length} chars, content-type={ContentType}).", payloadAsString.Length, msg.ContentType);
+                this.RaisePropertyChanged(nameof(ShowJsonParseError));
+                this.RaisePropertyChanged(nameof(IsAnyPayloadViewerVisible));
+                return;
+            }
+
             JsonViewer.LoadJson(payloadAsString);
             if (string.IsNullOrEmpty(JsonViewer.JsonParseError))
             {

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -309,6 +309,11 @@
                       <!-- JSON Viewer (Conditionally Visible) -->
                       <Border BorderBrush="Gray" BorderThickness="1" IsVisible="{Binding IsJsonViewerVisible}">
                           <TreeView ItemsSource="{Binding JsonViewer.RootNodes}" MinWidth="200">
+                              <TreeView.ItemsPanel>
+                                  <ItemsPanelTemplate>
+                                      <VirtualizingStackPanel />
+                                  </ItemsPanelTemplate>
+                              </TreeView.ItemsPanel>
                               <TreeView.Styles>
                                   <Style Selector="TreeViewItem">
                                       <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -157,6 +157,10 @@ engine.MessagesBatchReceived += (sender, batch) =>
         };
 
         await engine.ConnectAsync(cts.Token);
+        // Wait briefly so the engine's automatic subscription to "#" is registered
+        // with the broker before we publish. Without this, the publish can race
+        // ahead of the SUBSCRIBE and the message is never routed to the engine.
+        await Task.Delay(500, cts.Token);
 
         // Act: Publish a test message with an empty payload.
         var factory = new MqttClientFactory();
@@ -330,6 +334,10 @@ engine.MessagesBatchReceived += (sender, batch) =>
         try
         {
             await engine.ConnectAsync(cts.Token);
+            // Wait briefly so the engine's automatic subscription to "#" completes
+            // before our explicit SubscribeAsync call, avoiding a race where the
+            // background subscribe's timeout tears down the connection mid-test.
+            await Task.Delay(500, cts.Token);
 
             // Act
             var result = await engine.SubscribeAsync("test/subscribe/topic", MqttQualityOfServiceLevel.AtLeastOnce);

--- a/tests/UnitTests/ViewModels/JsonViewerViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/JsonViewerViewModelTests.cs
@@ -467,5 +467,86 @@ namespace UnitTests.ViewModels
             Assert.Contains("🌍", vm.RootNodes[0].ValueDisplay);
             Assert.Contains("世界", vm.RootNodes[1].ValueDisplay);
         }
+
+        [Fact]
+        public void LoadJson_LargeSubtree_IsNotAutoExpanded()
+        {
+            // Root object has one property 'big' whose value is a flat object with many leaves.
+            // With AutoExpandNodeBudget=500 the 'big' subtree (>500 children) must stay collapsed
+            // so the TreeView doesn't need to materialize thousands of items synchronously.
+            int childCount = JsonViewerViewModel.AutoExpandNodeBudget + 50;
+            var sb = new System.Text.StringBuilder();
+            sb.Append("{\"big\":{");
+            for (int i = 0; i < childCount; i++)
+            {
+                if (i > 0) sb.Append(',');
+                sb.Append('"').Append("k").Append(i).Append("\":").Append(i);
+            }
+            sb.Append("}}");
+
+            var vm = new JsonViewerViewModel();
+            vm.LoadJson(sb.ToString());
+
+            Assert.False(vm.HasParseError);
+            Assert.Single(vm.RootNodes);
+            var bigNode = vm.RootNodes[0];
+            Assert.Equal("big", bigNode.Name);
+            Assert.Equal(childCount, bigNode.Children.Count);
+            // Budget exceeded -> must not be auto-expanded
+            Assert.False(bigNode.IsExpanded);
+        }
+
+        [Fact]
+        public void LoadJson_SmallSubtree_IsStillAutoExpanded()
+        {
+            // Small nested object well under the budget should keep the existing
+            // depth-5 auto-expand UX.
+            var vm = new JsonViewerViewModel();
+            vm.LoadJson("{\"outer\":{\"inner\":{\"leaf\":42}}}");
+
+            Assert.False(vm.HasParseError);
+            var outer = vm.RootNodes[0];
+            Assert.True(outer.IsExpanded);
+            var inner = outer.Children[0];
+            Assert.True(inner.IsExpanded);
+        }
+
+        [Fact]
+        public void LoadJson_LargeArrayRoot_IsNotAutoExpanded()
+        {
+            // A top-level array larger than the budget should also stay collapsed
+            // on load to avoid the TreeView materializing thousands of value nodes.
+            int n = JsonViewerViewModel.AutoExpandNodeBudget + 10;
+            var json = "[" + string.Join(",", Enumerable.Range(0, n).Select(i => i.ToString())) + "]";
+
+            var vm = new JsonViewerViewModel();
+            vm.LoadJson(json);
+
+            Assert.False(vm.HasParseError);
+            Assert.Single(vm.RootNodes);
+            var arrayRoot = vm.RootNodes[0];
+            Assert.Equal(n, arrayRoot.Children.Count);
+            Assert.False(arrayRoot.IsExpanded);
+        }
+
+        [Fact]
+        public void LoadJson_TruncatesVeryLongStringValue()
+        {
+            // Embedded long string inside JSON (simulates base64 blob) should be
+            // truncated in ValueDisplay to keep per-item rendering cheap.
+            int len = JsonNodeViewModel.MaxValueDisplayLength + 250;
+            string big = new string('a', len);
+            string json = "{\"blob\":\"" + big + "\"}";
+
+            var vm = new JsonViewerViewModel();
+            vm.LoadJson(json);
+
+            Assert.False(vm.HasParseError);
+            var node = vm.RootNodes[0];
+            Assert.True(node.ValueDisplay.Length < len + 2,
+                $"ValueDisplay length {node.ValueDisplay.Length} should be much smaller than raw length {len}");
+            Assert.Contains("…", node.ValueDisplay);
+            Assert.Contains($"{len} chars", node.ValueDisplay);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the JSON viewer's performance and usability, especially when handling large or deeply nested JSON payloads. The main changes include limiting automatic expansion of large subtrees, truncating very long string values in the tree view, and adding safeguards to prevent UI freezes with oversized payloads. Several new tests ensure these behaviors work as intended.

**Performance and Usability Improvements for JSON Viewer:**

* Added constants `AutoExpandMaxDepth` and `AutoExpandNodeBudget` to `JsonViewerViewModel` to control automatic expansion: subtrees deeper than 5 levels or with more than 500 descendants are now collapsed by default, preventing the UI from rendering thousands of nodes at once. [[1]](diffhunk://#diff-75245b4d6758676ddefc4061c60ba595468854c323215edc98a1bd32ca40fc5fR14-R27) [[2]](diffhunk://#diff-75245b4d6758676ddefc4061c60ba595468854c323215edc98a1bd32ca40fc5fL66-R86) [[3]](diffhunk://#diff-75245b4d6758676ddefc4061c60ba595468854c323215edc98a1bd32ca40fc5fL92-R153) [[4]](diffhunk://#diff-75245b4d6758676ddefc4061c60ba595468854c323215edc98a1bd32ca40fc5fL123-R180) [[5]](diffhunk://#diff-75245b4d6758676ddefc4061c60ba595468854c323215edc98a1bd32ca40fc5fR191)
* Introduced `MaxValueDisplayLength` in `JsonNodeViewModel` to truncate very long string values (e.g., base64 blobs) in the tree display, appending an ellipsis and length hint to keep rendering responsive. [[1]](diffhunk://#diff-e7f019d64eebcad0d6fcce081f06e0145c0cdffb49a5003c80cfde542d2ead74R13-R21) [[2]](diffhunk://#diff-e7f019d64eebcad0d6fcce081f06e0145c0cdffb49a5003c80cfde542d2ead74L53-R91)
* Updated the JSON viewer UI (`MainView.axaml`) to use a `VirtualizingStackPanel`, improving performance when displaying large collections of nodes.
* Added a safety guard in `MainViewModel` to avoid automatic JSON tree view for very large payloads (>2MB) unless the content-type explicitly indicates JSON, defaulting to the raw viewer instead.

**Testing Enhancements:**

* Added new unit tests to verify that large subtrees and arrays are not auto-expanded, small subtrees still auto-expand as before, and long string values are properly truncated in the display.

**Test Stability Improvements:**

* Added brief delays in MQTT engine unit tests to prevent race conditions between subscription registration and message publishing, ensuring test reliability. [[1]](diffhunk://#diff-d0996201c2204417dfa564a28ba106c1921acfb78c9b88848654af0cf46f01b3R160-R163) [[2]](diffhunk://#diff-d0996201c2204417dfa564a28ba106c1921acfb78c9b88848654af0cf46f01b3R337-R340)