### PR TITLE
Various pipeline updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Upload Application (${{ matrix.runtime }})
       if: matrix.runtime != 'osx-x64' && matrix.runtime != 'osx-arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: crows-nest-mqtt-${{ matrix.runtime }}-${{ needs.determine_version.outputs.semVer }} # Use version from needs context
         path: ./publish/${{ matrix.runtime }}
@@ -95,7 +95,7 @@ jobs:
 
     - name: Upload macOS DMG (${{ matrix.runtime }})
       if: matrix.runtime == 'osx-x64' || matrix.runtime == 'osx-arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: crows-nest-mqtt-${{ matrix.runtime }}-${{ needs.determine_version.outputs.semVer }} # Use version from needs context
         path: ./publish/${{ matrix.runtime }}/*.dmg
@@ -120,7 +120,7 @@ jobs:
 
     - name: Upload MSIX (${{ matrix.runtime }})
       if: matrix.runtime == 'win-x64' || matrix.runtime == 'win-arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: crows-nest-mqtt-msix-${{ matrix.runtime }}-${{ needs.determine_version.outputs.semVer }}
         path: ./publish/msix/*.msix
@@ -136,13 +136,13 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Download win-x64 MSIX
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: crows-nest-mqtt-msix-win-x64-${{ needs.determine_version.outputs.semVer }}
         path: ./msix-inputs/
 
     - name: Download win-arm64 MSIX
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: crows-nest-mqtt-msix-win-arm64-${{ needs.determine_version.outputs.semVer }}
         path: ./msix-inputs/
@@ -156,7 +156,7 @@ jobs:
           -OutputPath "./publish/bundle/CrowsNestMqtt-${{ needs.determine_version.outputs.semVer }}.msixbundle"
 
     - name: Upload MSIX Bundle
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: crows-nest-mqtt-msixbundle-${{ needs.determine_version.outputs.semVer }}
         path: ./publish/bundle/*.msixbundle
@@ -173,7 +173,7 @@ jobs:
       contents: write
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         path: ./release/
          

--- a/tools/Create-MsixPackage.ps1
+++ b/tools/Create-MsixPackage.ps1
@@ -114,6 +114,13 @@ if (-not (Test-Path $AssetsDir)) {
     exit 1
 }
 
+# Determine host architecture for SDK tool selection (tools must run on the host,
+# regardless of the target architecture we're packaging for)
+$hostArch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    'ARM64' { 'arm64' }
+    default { 'x64' }
+}
+
 # Find Windows SDK tools
 function Find-SdkTool {
     param([string]$ToolName)
@@ -130,14 +137,16 @@ function Find-SdkTool {
         Sort-Object { [Version]$_.Name } -Descending
 
     foreach ($sdkVersion in $sdkVersions) {
-        $toolPath = Join-Path $sdkVersion.FullName "$Architecture\$ToolName"
+        $toolPath = Join-Path $sdkVersion.FullName "$hostArch\$ToolName"
         if (Test-Path $toolPath) {
             return $toolPath
         }
-        # Fallback to x64 for tools that might only exist in x64
-        $toolPathX64 = Join-Path $sdkVersion.FullName "x64\$ToolName"
-        if (Test-Path $toolPathX64) {
-            return $toolPathX64
+        # Fallback to x64 if host arch tool not found
+        if ($hostArch -ne 'x64') {
+            $toolPathX64 = Join-Path $sdkVersion.FullName "x64\$ToolName"
+            if (Test-Path $toolPathX64) {
+                return $toolPathX64
+            }
         }
     }
 


### PR DESCRIPTION
This pull request focuses on two main areas: updating GitHub Actions workflow steps to use newer versions of certain actions, and improving the robustness of the MSIX packaging script for Windows by making SDK tool selection architecture-aware.

**GitHub Actions workflow updates:**

* Updated all usages of `actions/upload-artifact` and `actions/download-artifact` from version 4 to version 6 in `.github/workflows/publish.yml` to ensure compatibility with the latest features and security updates. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L90-R98) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L123-R123) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L139-R145) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L159-R159) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L176-R176)

**MSIX packaging script improvements:**

* Added logic in `tools/Create-MsixPackage.ps1` to detect the host architecture (`x64` or `arm64`) and use it when selecting Windows SDK tools, ensuring the correct binaries are used regardless of the target architecture.
* Modified the `Find-SdkTool` function to use the detected host architecture, with a fallback to `x64` if the tool is not found for the host architecture, improving cross-architecture packaging reliability.