### PR TITLE
Enforce dotnet clean before publishing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,6 +42,21 @@
             "dependsOn": "build"
         },
         {
+            "label": "Clean MainApp",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "clean",
+                "${workspaceFolder}/src/MainApp/",
+                "--configuration",
+                "Release"
+            ],
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "Publish Crow's NestMQTT App",
             "command": "dotnet",
             "type": "shell",
@@ -58,7 +73,7 @@
                 "reveal": "always"
             },
             "problemMatcher": "$msCompile",
-            
+            "dependsOn": "Clean MainApp"
         }
     ]
 }


### PR DESCRIPTION
This pull request updates the `.vscode/tasks.json` file to improve the build process for the `MainApp` project. The main change is the introduction of a new clean step before publishing, ensuring that any previous build artifacts are removed for a cleaner, more reliable build.

Build process improvements:

* Added a new "Clean MainApp" task that runs `dotnet clean` on the `src/MainApp/` directory in Release configuration.
* Updated the "Publish Crow's NestMQTT App" task to depend on the new "Clean MainApp" task, ensuring the clean step is executed before publishing.