### PR TITLE
Allow more settings to be directly passed via environment variables to start Crow's NestMQTT in correct configuration (e.g. from aspire)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,13 @@ When connecting to a broker with Enhanced Authentication, the client and broker 
 
 ## dotnet Aspire
 
-Crow's NestMQTT is will automatically connect to the MQTT Broker endpoint, defined via dotnet Aspire environment variable, it expects service name to be `mqtt` and endpoint to be named `default`. For example environment variable `services__mqtt__default__0` would contain `mqtt://localhost:42069`.
+Crow's NestMQTT automatically connects to the MQTT Broker endpoint defined via dotnet Aspire environment variables. It supports both `services__mqtt__mqtt__0` and `services__mqtt__default__0` naming conventions. For example, the environment variable would contain a value like `mqtt://localhost:42069`.
+
+When an Aspire endpoint environment variable is detected, the application:
+1. Parses the hostname and port from the URI
+2. Overrides the corresponding settings
+3. Automatically connects to the broker on startup
+4. Persists the overridden values to `settings.json` so other tools can use them
 
 ```csharp
   // ...
@@ -229,6 +235,70 @@ Crow's NestMQTT is will automatically connect to the MQTT Broker endpoint, defin
       .AddExecutable("mqtt-client", Path.Combine(mqttViewerWorkingDirectory, "CrowsNestMqtt.App.exe"), mqttViewerWorkingDirectory)
       .WithReference(mqttBrokerEndpoint)
       .WaitFor(mqttBroker);
+```
+
+## Environment Variable Configuration
+
+All settings can be configured via environment variables using the `CROWSNEST__` prefix. When environment variable overrides are detected, they are applied on top of file-based settings and **persisted to `settings.json`** so other tools (e.g., `SendTestData.ps1`) can use the same configuration.
+
+This is useful for:
+- Running from dotnet Aspire (settings won't be overwritten)
+- Running integration tests with specific configuration
+- CI/CD environments
+- Docker containers
+
+### Available Environment Variables
+
+| Variable | Description | Type | Example |
+|---|---|---|---|
+| `services__mqtt__mqtt__0` | Aspire MQTT endpoint (triggers auto-connect) | URI | `mqtt://localhost:1883` |
+| `services__mqtt__default__0` | Aspire MQTT endpoint (alternative name) | URI | `mqtt://broker:8883` |
+| `CROWSNEST__HOSTNAME` | MQTT broker hostname | string | `mqtt.example.com` |
+| `CROWSNEST__PORT` | MQTT broker port | int | `8883` |
+| `CROWSNEST__CLIENT_ID` | MQTT client ID | string | `my-client` |
+| `CROWSNEST__KEEP_ALIVE_SECONDS` | Keep-alive interval in seconds | int | `30` |
+| `CROWSNEST__CLEAN_SESSION` | Whether to use clean session | bool | `true` |
+| `CROWSNEST__SESSION_EXPIRY_SECONDS` | Session expiry interval | uint | `300` |
+| `CROWSNEST__AUTH_MODE` | Authentication mode | enum | `anonymous`, `userpass`, `enhanced` |
+| `CROWSNEST__AUTH_USERNAME` | Username (when AUTH_MODE=userpass) | string | `myuser` |
+| `CROWSNEST__AUTH_PASSWORD` | Password (when AUTH_MODE=userpass) | string | `mypass` |
+| `CROWSNEST__AUTH_METHOD` | Enhanced auth method (when AUTH_MODE=enhanced) | string | `SCRAM-SHA-1` |
+| `CROWSNEST__AUTH_DATA` | Enhanced auth data (when AUTH_MODE=enhanced) | string | |
+| `CROWSNEST__USE_TLS` | Enable TLS encryption | bool | `true` |
+| `CROWSNEST__SUBSCRIPTION_QOS` | Subscription QoS level (0, 1, or 2) | int | `1` |
+| `CROWSNEST__EXPORT_FORMAT` | Default export format | enum | `json`, `txt` |
+| `CROWSNEST__EXPORT_PATH` | Default export file path | string | `/tmp/exports` |
+| `CROWSNEST__MAX_TOPIC_LIMIT` | Max topics for delete operations | int | `500` |
+| `CROWSNEST__PARALLELISM_DEGREE` | Parallelism for batch operations | int | `4` |
+| `CROWSNEST__TIMEOUT_SECONDS` | Operation timeout in seconds | int | `5` |
+| `CROWSNEST__DEFAULT_BUFFER_SIZE_BYTES` | Default per-topic buffer size | long | `1048576` |
+| `CROWSNEST__TOPIC_BUFFER_LIMITS` | Per-topic buffer limits (JSON array) | JSON | `[{"TopicFilter":"#","MaxSizeBytes":2097152}]` |
+
+### Priority
+
+1. `CROWSNEST__HOSTNAME` / `CROWSNEST__PORT` take highest priority for connection settings
+2. Aspire endpoint env vars (`services__mqtt__mqtt__0`, `services__mqtt__default__0`) are used as fallback for hostname/port
+3. File-based `settings.json` is the lowest priority (used when no env vars are set)
+
+### Example: Aspire Integration
+
+```bash
+# Set by Aspire automatically:
+services__mqtt__mqtt__0=mqtt://localhost:41883
+```
+
+### Example: Manual Configuration
+
+```bash
+# Override all connection settings
+export CROWSNEST__HOSTNAME=mqtt.production.com
+export CROWSNEST__PORT=8883
+export CROWSNEST__USE_TLS=true
+export CROWSNEST__AUTH_MODE=userpass
+export CROWSNEST__AUTH_USERNAME=svc-account
+export CROWSNEST__AUTH_PASSWORD=secret
+export CROWSNEST__CLIENT_ID=monitoring-client
+export CROWSNEST__KEEP_ALIVE_SECONDS=60
 ```
 
 ## Scripts

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -2,7 +2,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Add EMQX MQTT v5 broker as a Docker container with dynamic ports
 var mqttBroker = builder.AddContainer("mqtt", "emqx/emqx", "latest")
-    .WithEndpoint(targetPort: 1883, name: "default", scheme: "mqtt")
+    .WithEndpoint(targetPort: 1883, name: "mqtt", scheme: "mqtt")
     .WithHttpEndpoint(targetPort: 18083, name: "dashboard")
     .WithEnvironment("EMQX_ALLOW_ANONYMOUS", "true")
     .WithEnvironment("EMQX_AUTHORIZATION__NO_MATCH", "allow")
@@ -11,11 +11,19 @@ var mqttBroker = builder.AddContainer("mqtt", "emqx/emqx", "latest")
     .WithEnvironment("EMQX_MQTT__MAX_PACKET_SIZE", "10485760"); // 10MB max packet size
 
 // Get the MQTT endpoint for passing to the client application
-var mqttEndpoint = mqttBroker.GetEndpoint("default");
+var mqttEndpoint = mqttBroker.GetEndpoint("mqtt");
 
 // Add CrowsNestMqtt as a project that auto-connects to the MQTT broker
 builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt")
     .WithReference(mqttEndpoint)
-    .WaitFor(mqttBroker);
+    .WaitFor(mqttBroker)
+    .WithEnvironment("CROWSNEST__USE_TLS", "false")
+    .WithEnvironment("CROWSNEST__AUTH_MODE", "anonymous")
+    .WithEnvironment("CROWSNEST__CLIENT_ID", "")
+    .WithEnvironment("CROWSNEST__KEEP_ALIVE_SECONDS", "0")
+    .WithEnvironment("CROWSNEST__CLEAN_SESSION", "true")
+    .WithEnvironment("CROWSNEST__SESSION_EXPIRY_SECONDS", "0")
+    .WithEnvironment("CROWSNEST__SUBSCRIPTION_QOS", "1")
+    .WithEnvironment("CROWSNEST__TOPIC_BUFFER_LIMITS", """[{"TopicFilter":"#","MaxSizeBytes":11048576}]""");
 
 builder.Build().Run();

--- a/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
+++ b/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
@@ -1,0 +1,234 @@
+namespace CrowsNestMqtt.BusinessLogic.Configuration;
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using CrowsNestMqtt.BusinessLogic.Exporter;
+using CrowsNestMqtt.Utils;
+
+/// <summary>
+/// Reads application settings from environment variables.
+/// When overrides are detected, they are applied on top of file-based settings
+/// and persisted to settings.json so other tools can use them.
+/// </summary>
+public sealed record EnvironmentSettingsOverrides
+{
+    private const string Prefix = "CROWSNEST__";
+    private const string AspireDefaultEnvVar = "services__mqtt__default__0";
+    private const string AspireMqttEnvVar = "services__mqtt__mqtt__0";
+
+    public string? Hostname { get; init; }
+    public int? Port { get; init; }
+    public string? ClientId { get; init; }
+    public int? KeepAliveIntervalSeconds { get; init; }
+    public bool? CleanSession { get; init; }
+    public uint? SessionExpiryIntervalSeconds { get; init; }
+    public AuthenticationMode? AuthMode { get; init; }
+    public bool? UseTls { get; init; }
+    public int? SubscriptionQoS { get; init; }
+    public ExportTypes? ExportFormat { get; init; }
+    public string? ExportPath { get; init; }
+    public int? MaxTopicLimit { get; init; }
+    public int? ParallelismDegree { get; init; }
+    public int? TimeoutPeriodSeconds { get; init; }
+    public long? DefaultTopicBufferSizeBytes { get; init; }
+    public IList<TopicBufferLimit>? TopicSpecificBufferLimits { get; init; }
+
+    /// <summary>
+    /// Whether any environment variable overrides were detected.
+    /// </summary>
+    public bool HasOverrides { get; init; }
+
+    /// <summary>
+    /// Whether Aspire endpoint environment variables were detected (triggers auto-connect).
+    /// </summary>
+    public bool IsAspireEnvironment { get; init; }
+
+    /// <summary>
+    /// Reads settings from environment variables.
+    /// Returns an instance with HasOverrides=false if no relevant env vars are found.
+    /// </summary>
+    public static EnvironmentSettingsOverrides Load()
+    {
+        string? hostname = null;
+        int? port = null;
+        bool isAspire = false;
+
+        // Check Aspire endpoint env vars (lower priority than explicit CROWSNEST__ vars)
+        var aspireEndpoint = Environment.GetEnvironmentVariable(AspireMqttEnvVar)
+                          ?? Environment.GetEnvironmentVariable(AspireDefaultEnvVar);
+
+        if (!string.IsNullOrEmpty(aspireEndpoint))
+        {
+            isAspire = true;
+            var (aspireHost, aspirePort) = ParseMqttUri(aspireEndpoint);
+            hostname = aspireHost;
+            port = aspirePort;
+        }
+
+        // Read individual CROWSNEST__ env vars (these override Aspire values)
+        var envHostname = ReadString("HOSTNAME");
+        var envPort = ReadInt("PORT");
+        var clientId = ReadStringAllowEmpty("CLIENT_ID");
+        var keepAlive = ReadInt("KEEP_ALIVE_SECONDS");
+        var cleanSession = ReadBool("CLEAN_SESSION");
+        var sessionExpiry = ReadUInt("SESSION_EXPIRY_SECONDS");
+        var useTls = ReadBool("USE_TLS");
+        var subscriptionQoS = ReadInt("SUBSCRIPTION_QOS");
+        var exportFormat = ReadExportFormat("EXPORT_FORMAT");
+        var exportPath = ReadString("EXPORT_PATH");
+        var maxTopicLimit = ReadInt("MAX_TOPIC_LIMIT");
+        var parallelismDegree = ReadInt("PARALLELISM_DEGREE");
+        var timeoutSeconds = ReadInt("TIMEOUT_SECONDS");
+        var defaultBufferSize = ReadLong("DEFAULT_BUFFER_SIZE_BYTES");
+        var topicLimits = ReadTopicBufferLimits("TOPIC_BUFFER_LIMITS");
+        var authMode = ReadAuthMode();
+
+        // Explicit CROWSNEST__ hostname/port override Aspire-derived values
+        if (envHostname != null) hostname = envHostname;
+        if (envPort.HasValue) port = envPort;
+
+        bool hasAny = isAspire
+            || envHostname != null || envPort.HasValue
+            || clientId != null || keepAlive.HasValue
+            || cleanSession.HasValue || sessionExpiry.HasValue
+            || useTls.HasValue || subscriptionQoS.HasValue
+            || exportFormat.HasValue || exportPath != null
+            || maxTopicLimit.HasValue || parallelismDegree.HasValue
+            || timeoutSeconds.HasValue || defaultBufferSize.HasValue
+            || topicLimits != null || authMode != null;
+
+        if (hasAny)
+        {
+            AppLogger.Information("Environment variable overrides detected. Settings will be updated.");
+        }
+
+        return new EnvironmentSettingsOverrides
+        {
+            Hostname = hostname,
+            Port = port,
+            ClientId = clientId,
+            KeepAliveIntervalSeconds = keepAlive,
+            CleanSession = cleanSession,
+            SessionExpiryIntervalSeconds = sessionExpiry,
+            AuthMode = authMode,
+            UseTls = useTls,
+            SubscriptionQoS = subscriptionQoS,
+            ExportFormat = exportFormat,
+            ExportPath = exportPath,
+            MaxTopicLimit = maxTopicLimit,
+            ParallelismDegree = parallelismDegree,
+            TimeoutPeriodSeconds = timeoutSeconds,
+            DefaultTopicBufferSizeBytes = defaultBufferSize,
+            TopicSpecificBufferLimits = topicLimits,
+            HasOverrides = hasAny,
+            IsAspireEnvironment = isAspire
+        };
+    }
+
+    internal static (string? hostname, int? port) ParseMqttUri(string connectionString)
+    {
+        try
+        {
+            var uri = new Uri(connectionString);
+            if (!string.IsNullOrEmpty(uri.Host) && uri.Port > 0)
+            {
+                return (uri.Host, uri.Port);
+            }
+        }
+        catch (UriFormatException ex)
+        {
+            AppLogger.Error(ex, "Invalid URI format for MQTT connection string: {ConnectionString}", connectionString);
+        }
+
+        return (null, null);
+    }
+
+    private static AuthenticationMode? ReadAuthMode()
+    {
+        var mode = ReadString("AUTH_MODE");
+        if (mode == null) return null;
+
+        return mode.ToLowerInvariant() switch
+        {
+            "anonymous" => new AnonymousAuthenticationMode(),
+            "userpass" or "usernamepassword" => new UsernamePasswordAuthenticationMode(
+                ReadString("AUTH_USERNAME") ?? string.Empty,
+                ReadString("AUTH_PASSWORD") ?? string.Empty),
+            "enhanced" => new EnhancedAuthenticationMode(
+                ReadString("AUTH_METHOD"),
+                ReadString("AUTH_DATA")),
+            _ => null
+        };
+    }
+
+    private static string? ReadString(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(Prefix + name);
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static string? ReadStringAllowEmpty(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(Prefix + name);
+        // Returns null only if the env var is not set at all
+        return value;
+    }
+
+    private static int? ReadInt(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && int.TryParse(value, out var result))
+            return result;
+        return null;
+    }
+
+    private static uint? ReadUInt(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && uint.TryParse(value, out var result))
+            return result;
+        return null;
+    }
+
+    private static long? ReadLong(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && long.TryParse(value, out var result))
+            return result;
+        return null;
+    }
+
+    private static bool? ReadBool(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && bool.TryParse(value, out var result))
+            return result;
+        return null;
+    }
+
+    private static ExportTypes? ReadExportFormat(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && Enum.TryParse<ExportTypes>(value, ignoreCase: true, out var result))
+            return result;
+        return null;
+    }
+
+    private static IList<TopicBufferLimit>? ReadTopicBufferLimits(string name)
+    {
+        var value = ReadString(name);
+        if (value == null) return null;
+
+        try
+        {
+            var limits = JsonSerializer.Deserialize<List<TopicBufferLimit>>(value);
+            return limits;
+        }
+        catch (JsonException ex)
+        {
+            AppLogger.Error(ex, "Failed to parse {EnvVar} environment variable as JSON", Prefix + name);
+            return null;
+        }
+    }
+}

--- a/src/MainApp/Program.cs
+++ b/src/MainApp/Program.cs
@@ -6,6 +6,7 @@ using CrowsNestMqtt.UI.ViewModels;
 using CrowsNestMqtt.UI.Views;
 using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.BusinessLogic.Contracts; // Added for IMessageCorrelationService
+using CrowsNestMqtt.BusinessLogic.Configuration; // Added for EnvironmentSettingsOverrides
 using CrowsNestMqtt.UI.Services; // Added for ResponseIconService
 using CrowsNestMqtt.UI.Contracts; // Added for IResponseIconService
 using Microsoft.Extensions.Logging;
@@ -77,8 +78,8 @@ class Program
         try
         {
             Log.Information("Starting application");
-            (var aspireHostname, var aspirePort) = LoadMqttEndpointFromEnv();
-            BuildAvaloniaApp(aspireHostname, aspirePort).StartWithClassicDesktopLifetime(args);
+            var environmentOverrides = EnvironmentSettingsOverrides.Load();
+            BuildAvaloniaApp(environmentOverrides).StartWithClassicDesktopLifetime(args);
         }
         catch (Exception ex)
         {
@@ -90,7 +91,7 @@ class Program
         }
     }
 
-    public static AppBuilder BuildAvaloniaApp(string? aspireHostname = null, int? aspirePort = null)
+    public static AppBuilder BuildAvaloniaApp(EnvironmentSettingsOverrides? environmentOverrides = null)
     {
         return AppBuilder.Configure<CrowsNestMqtt.UI.App>() // Configure the App from UI project
             .UsePlatformDetect()
@@ -118,10 +119,10 @@ class Program
 
                     desktop.MainWindow = new MainWindow
                     {
-                        DataContext = new MainViewModel(commandParserService, null, deleteTopicService, correlationService, iconService, aspireHostname, aspirePort, publishHistoryService: publishHistoryService, fileAutoCompleteService: fileAutoCompleteService)
+                        DataContext = new MainViewModel(commandParserService, null, deleteTopicService, correlationService, iconService, environmentOverrides, publishHistoryService: publishHistoryService, fileAutoCompleteService: fileAutoCompleteService)
                     };
 
-                    if (!string.IsNullOrEmpty(aspireHostname) && aspirePort.HasValue)
+                    if (environmentOverrides?.IsAspireEnvironment == true)
                     {
                         (desktop.MainWindow.DataContext as MainViewModel)?.ConnectCommand.Execute().Subscribe();
                     }
@@ -197,40 +198,4 @@ class Program
         // if (e.IsTerminating) { Environment.Exit(1); }
     }
 
-    private static (string? aspireHostname, int? aspirePort) LoadMqttEndpointFromEnv()
-    {
-        string? aspireHostname = null;
-        int? aspirePort = null;
-        const string aspireMqttEnvVar = "services__mqtt__default__0";
-        var mqttConnectionString = Environment.GetEnvironmentVariable(aspireMqttEnvVar);
-
-        if (!string.IsNullOrEmpty(mqttConnectionString))
-        {
-            Log.Information("Found Aspire MQTT connection string from environment variable {EnvVarName}: {ConnectionString}", aspireMqttEnvVar, mqttConnectionString);
-            try
-            {
-                var uri = new Uri(mqttConnectionString);
-                if (!string.IsNullOrEmpty(uri.Host) && uri.Port > 0)
-                {
-                    aspireHostname = uri.Host;
-                    aspirePort = uri.Port;
-                    Log.Information("Successfully parsed Aspire MQTT configuration. Hostname: {Hostname}, Port: {Port}", aspireHostname, aspirePort);
-                }
-                else
-                {
-                    Log.Error("Failed to parse Hostname/Port from Aspire MQTT connection string: {ConnectionString}. Host or Port missing or invalid.", mqttConnectionString);
-                }
-            }
-            catch (UriFormatException ex)
-            {
-                Log.Error(ex, "Invalid URI format for Aspire MQTT connection string: {ConnectionString}", mqttConnectionString);
-            }
-        }
-        else
-        {
-            Log.Information("Aspire MQTT environment variable {EnvVarName} not found or empty.", aspireMqttEnvVar);
-        }
-
-        return (aspireHostname, aspirePort);
-    }
 }

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -36,6 +36,7 @@ using System.Reactive.Concurrency;
 using System.Linq;
 using CrowsNestMQTT.BusinessLogic.Navigation; // Added for keyboard navigation
 using Avalonia.Input; // Added for KeyModifiers
+using CrowsNestMqtt.BusinessLogic.Configuration; // Added for EnvironmentSettingsOverrides
 
 namespace CrowsNestMqtt.UI.ViewModels;
 
@@ -50,6 +51,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     private readonly IDeleteTopicService? _deleteTopicService; // Added delete topic service
     private readonly IMessageCorrelationService? _correlationService; // Added correlation service for request-response tracking
     private readonly IResponseIconService? _iconService; // Added icon service for UI status updates
+    private readonly EnvironmentSettingsOverrides? _environmentOverrides; // Environment variable overrides
     private Timer? _updateTimer;
     private Timer? _uiHeartbeatTimer;
     private DateTime _lastHeartbeatPosted = DateTime.MinValue;
@@ -751,7 +753,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     /// Sets up placeholder data and starts the UI update timer.
     /// </summary>
     // Constructor now requires ICommandParserService
-    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, string? aspireHostname = null, int? aspirePort = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null)
+    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, EnvironmentSettingsOverrides? environmentOverrides = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null)
     {
         _commandParserService = commandParserService ?? throw new ArgumentNullException(nameof(commandParserService)); // Store injected service
         _deleteTopicService = deleteTopicService; // Store injected delete topic service (optional)
@@ -767,7 +769,8 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
                     || Environment.GetEnvironmentVariable("CI") == "true"
                     || uiScheduler == Scheduler.Immediate; // If ImmediateScheduler is injected, we're definitely in test mode
         _syncContext = SynchronizationContext.Current; // Capture sync context
-        Settings = new SettingsViewModel(); // Instantiate settings
+        Settings = new SettingsViewModel(environmentOverrides); // Instantiate settings with env overrides
+        _environmentOverrides = environmentOverrides;
         JsonViewer = new JsonViewerViewModel(); // Instantiate JSON viewer VM
         CopyTextToClipboardInteraction = new Interaction<string, Unit>(); // Initialize the interaction
         CopyImageToClipboardInteraction = new Interaction<Bitmap, Unit>(); // Initialize the image interaction
@@ -1029,15 +1032,8 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
             this.RaisePropertyChanged(nameof(IsExportAllButtonEnabled));
         }
 
-        if (!string.IsNullOrEmpty(aspireHostname) && aspirePort.HasValue)
-        {
-            if (aspirePort.Value > 0 && aspirePort.Value < 65535)
-            {
-                Log.Information("Using Aspire-provided MQTT configuration. Hostname: {Hostname}, Port: {Port}", aspireHostname, aspirePort.Value);
-                Settings.Hostname = aspireHostname; // Example if you want to update the UI settings fields
-                Settings.Port = aspirePort.Value;
-            }
-        }
+        // Environment overrides are already applied via SettingsViewModel constructor.
+        // No need to manually set hostname/port here - the SettingsVM handles it.
 
         // Use the injected mqttService if available (for testing), otherwise create a new one.
         _mqttService = mqttService ?? new MqttEngine(new MqttConnectionSettings

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -91,11 +91,17 @@ public class SettingsViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _subscriptionQoS, Math.Clamp(value, 0, 2));
     }
 
-    public SettingsViewModel()
+    public SettingsViewModel(EnvironmentSettingsOverrides? environmentOverrides = null)
     {
         ExportPath = _exportFolderPath; // Set default before loading
         _isLoading = true; // Set flag before loading
         LoadSettings(); // This calls From() which populates TopicSpecificLimits
+
+        // Apply environment variable overrides after loading from file
+        if (environmentOverrides?.HasOverrides == true)
+        {
+            ApplyEnvironmentOverrides(environmentOverrides);
+        }
 
         _isLoading = false; // Clear flag after loading
 
@@ -396,6 +402,62 @@ public class SettingsViewModel : ReactiveObject
             AuthPassword = string.Empty;
             AuthenticationMethod = null;
             AuthenticationData = null;
+        }
+    }
+
+    /// <summary>
+    /// Applies environment variable overrides on top of file-based settings.
+    /// Only non-null properties in the overrides are applied.
+    /// </summary>
+    internal void ApplyEnvironmentOverrides(EnvironmentSettingsOverrides overrides)
+    {
+        if (overrides.Hostname != null) Hostname = overrides.Hostname;
+        if (overrides.Port.HasValue) Port = overrides.Port.Value;
+        if (overrides.ClientId != null) ClientId = overrides.ClientId;
+        if (overrides.KeepAliveIntervalSeconds.HasValue) KeepAliveIntervalSeconds = overrides.KeepAliveIntervalSeconds.Value;
+        if (overrides.CleanSession.HasValue) CleanSession = overrides.CleanSession.Value;
+        if (overrides.SessionExpiryIntervalSeconds.HasValue) SessionExpiryIntervalSeconds = overrides.SessionExpiryIntervalSeconds.Value;
+        if (overrides.UseTls.HasValue) UseTls = overrides.UseTls.Value;
+        if (overrides.SubscriptionQoS.HasValue) SubscriptionQoS = overrides.SubscriptionQoS.Value;
+        if (overrides.ExportFormat.HasValue) ExportFormat = overrides.ExportFormat.Value;
+        if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
+
+        if (overrides.AuthMode != null)
+        {
+            if (overrides.AuthMode is EnhancedAuthenticationMode enhanced)
+            {
+                SelectedAuthMode = AuthModeSelection.Enhanced;
+                AuthenticationMethod = enhanced.AuthenticationMethod;
+                AuthenticationData = enhanced.AuthenticationData;
+                AuthUsername = string.Empty;
+                AuthPassword = string.Empty;
+            }
+            else if (overrides.AuthMode is UsernamePasswordAuthenticationMode userPass)
+            {
+                SelectedAuthMode = AuthModeSelection.UsernamePassword;
+                AuthUsername = userPass.Username;
+                AuthPassword = userPass.Password;
+                AuthenticationMethod = null;
+                AuthenticationData = null;
+            }
+            else
+            {
+                SelectedAuthMode = AuthModeSelection.Anonymous;
+                AuthUsername = string.Empty;
+                AuthPassword = string.Empty;
+                AuthenticationMethod = null;
+                AuthenticationData = null;
+            }
+        }
+
+        if (overrides.TopicSpecificBufferLimits != null)
+        {
+            TopicSpecificLimits.Clear();
+            foreach (var limit in overrides.TopicSpecificBufferLimits)
+            {
+                TopicSpecificLimits.Add(new TopicBufferLimitViewModel(limit));
+            }
+            EnsureDefaultTopicLimit();
         }
     }
 

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using CrowsNestMqtt.App;
+using CrowsNestMqtt.BusinessLogic.Configuration;
 using System.Reflection;
 using Avalonia;
 using System.Timers;
@@ -29,77 +30,106 @@ namespace CrowsNestMqtt.UnitTests
         }
         
         [Fact]
-        public void LoadMqttEndpointFromEnv_ReturnsNullValuesWhenEnvironmentVariablesNotSet()
+        public void EnvironmentSettingsOverrides_ReturnsNoOverridesWhenNoEnvVarsSet()
         {
             // Arrange
             Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+            Environment.SetEnvironmentVariable("services__mqtt__mqtt__0", null);
+            Environment.SetEnvironmentVariable("CROWSNEST__HOSTNAME", null);
 
-            // Act - Using the correct tuple type
-            var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+            // Act
+            var result = EnvironmentSettingsOverrides.Load();
 
             // Assert
-            Assert.Null(result.Item1); // Should return null when environment variable is not set
-            Assert.Null(result.Item2); // Should return null when environment variable is not set
+            Assert.False(result.HasOverrides);
+            Assert.False(result.IsAspireEnvironment);
+            Assert.Null(result.Hostname);
+            Assert.Null(result.Port);
         }
 
         [Fact]
-        public void LoadMqttEndpointFromEnv_ReturnsCustomValuesWhenEnvironmentVariablesSet()
+        public void EnvironmentSettingsOverrides_ParsesAspireDefaultEnvVar()
         {
             // Arrange
             try
             {
                 Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://test.mqtt.server:8883");
 
-                // Act - Using the correct tuple type
-                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+                // Act
+                var result = EnvironmentSettingsOverrides.Load();
 
                 // Assert
-                Assert.Equal("test.mqtt.server", result.Item1);
-                Assert.Equal(8883, result.Item2);
+                Assert.True(result.HasOverrides);
+                Assert.True(result.IsAspireEnvironment);
+                Assert.Equal("test.mqtt.server", result.Hostname);
+                Assert.Equal(8883, result.Port);
             }
             finally
             {
-                // Clean up
                 Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
             }
         }
 
         [Fact]
-        public void LoadMqttEndpointFromEnv_HandlesInvalidUriFormat()
+        public void EnvironmentSettingsOverrides_ParsesAspireMqttEnvVar()
+        {
+            // Arrange
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtt__0", "mqtt://aspire.host:41883");
+
+                // Act
+                var result = EnvironmentSettingsOverrides.Load();
+
+                // Assert
+                Assert.True(result.HasOverrides);
+                Assert.True(result.IsAspireEnvironment);
+                Assert.Equal("aspire.host", result.Hostname);
+                Assert.Equal(41883, result.Port);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtt__0", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_MqttEnvVarTakesPriorityOverDefault()
+        {
+            // Arrange
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtt__0", "mqtt://priority.host:9999");
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://fallback.host:1111");
+
+                // Act
+                var result = EnvironmentSettingsOverrides.Load();
+
+                // Assert
+                Assert.Equal("priority.host", result.Hostname);
+                Assert.Equal(9999, result.Port);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtt__0", null);
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_HandlesInvalidUri()
         {
             // Arrange
             try
             {
                 Environment.SetEnvironmentVariable("services__mqtt__default__0", "invalid-uri");
 
-                // Act - Using the correct tuple type
-                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
-
-                // Assert
-                Assert.Null(result.Item1); // Should return null for invalid URI
-                Assert.Null(result.Item2); // Should return null for invalid URI
-            }
-            finally
-            {
-                // Clean up
-                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
-            }
-        }
-
-        [Fact]
-        public void LoadMqttEndpointFromEnv_HandlesEmptyHostname()
-        {
-            // Arrange
-            try
-            {
-                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://:1883");
-
                 // Act
-                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+                var result = EnvironmentSettingsOverrides.Load();
 
-                // Assert
-                Assert.Null(result.Item1);
-                Assert.Null(result.Item2);
+                // Assert - invalid URI means no host/port parsed, but IsAspire is still true
+                Assert.Null(result.Hostname);
+                Assert.Null(result.Port);
             }
             finally
             {
@@ -108,45 +138,105 @@ namespace CrowsNestMqtt.UnitTests
         }
 
         [Fact]
-        public void LoadMqttEndpointFromEnv_HandlesZeroPort()
+        public void EnvironmentSettingsOverrides_CrowsnestVarsOverrideAspire()
         {
             // Arrange
             try
             {
-                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://test.server:0");
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://aspire.host:1883");
+                Environment.SetEnvironmentVariable("CROWSNEST__HOSTNAME", "override.host");
+                Environment.SetEnvironmentVariable("CROWSNEST__PORT", "9999");
 
                 // Act
-                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+                var result = EnvironmentSettingsOverrides.Load();
 
                 // Assert
-                Assert.Null(result.Item1);
-                Assert.Null(result.Item2);
+                Assert.Equal("override.host", result.Hostname);
+                Assert.Equal(9999, result.Port);
+                Assert.True(result.IsAspireEnvironment);
             }
             finally
             {
                 Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__HOSTNAME", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__PORT", null);
             }
         }
 
         [Fact]
-        public void LoadMqttEndpointFromEnv_HandlesNegativePort()
+        public void EnvironmentSettingsOverrides_ParsesAllCrowsnestVars()
         {
             // Arrange
             try
             {
-                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://test.server:-1");
+                Environment.SetEnvironmentVariable("CROWSNEST__HOSTNAME", "mybroker");
+                Environment.SetEnvironmentVariable("CROWSNEST__PORT", "8883");
+                Environment.SetEnvironmentVariable("CROWSNEST__CLIENT_ID", "test-client");
+                Environment.SetEnvironmentVariable("CROWSNEST__KEEP_ALIVE_SECONDS", "30");
+                Environment.SetEnvironmentVariable("CROWSNEST__CLEAN_SESSION", "false");
+                Environment.SetEnvironmentVariable("CROWSNEST__SESSION_EXPIRY_SECONDS", "600");
+                Environment.SetEnvironmentVariable("CROWSNEST__USE_TLS", "true");
+                Environment.SetEnvironmentVariable("CROWSNEST__SUBSCRIPTION_QOS", "2");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", "userpass");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_USERNAME", "user1");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_PASSWORD", "pass1");
 
                 // Act
-                var result = InvokeStaticMethod<ValueTuple<string?, int?>>(typeof(Program), "LoadMqttEndpointFromEnv");
+                var result = EnvironmentSettingsOverrides.Load();
 
                 // Assert
-                Assert.Null(result.Item1);
-                Assert.Null(result.Item2);
+                Assert.True(result.HasOverrides);
+                Assert.Equal("mybroker", result.Hostname);
+                Assert.Equal(8883, result.Port);
+                Assert.Equal("test-client", result.ClientId);
+                Assert.Equal(30, result.KeepAliveIntervalSeconds);
+                Assert.False(result.CleanSession);
+                Assert.Equal(600u, result.SessionExpiryIntervalSeconds);
+                Assert.True(result.UseTls);
+                Assert.Equal(2, result.SubscriptionQoS);
+                Assert.IsType<UsernamePasswordAuthenticationMode>(result.AuthMode);
+                var userPass = (UsernamePasswordAuthenticationMode)result.AuthMode!;
+                Assert.Equal("user1", userPass.Username);
+                Assert.Equal("pass1", userPass.Password);
             }
             finally
             {
-                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__HOSTNAME", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__PORT", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__CLIENT_ID", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__KEEP_ALIVE_SECONDS", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__CLEAN_SESSION", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__SESSION_EXPIRY_SECONDS", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__USE_TLS", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__SUBSCRIPTION_QOS", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_USERNAME", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_PASSWORD", null);
             }
+        }
+
+        [Fact]
+        public void ParseMqttUri_ValidUri_ReturnsHostAndPort()
+        {
+            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://localhost:41883");
+            Assert.Equal("localhost", host);
+            Assert.Equal(41883, port);
+        }
+
+        [Fact]
+        public void ParseMqttUri_EmptyHost_ReturnsNull()
+        {
+            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://:1883");
+            Assert.Null(host);
+            Assert.Null(port);
+        }
+
+        [Fact]
+        public void ParseMqttUri_InvalidUri_ReturnsNull()
+        {
+            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("not a uri at all");
+            Assert.Null(host);
+            Assert.Null(port);
         }
 
         [Fact]

--- a/tests/UnitTests/UI/AvaloniaTestBase.cs
+++ b/tests/UnitTests/UI/AvaloniaTestBase.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Headless;
 using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Configuration;
 using CrowsNestMqtt.UI.ViewModels;
 using CrowsNestMqtt.BusinessLogic.Services;
 using NSubstitute;
@@ -59,11 +60,11 @@ namespace CrowsNestMqtt.UnitTests.UI
         /// <summary>
         /// Creates a test main view model for testing
         /// </summary>
-        protected static MainViewModel CreateTestMainViewModel(string? aspireHostname = null, int? aspirePort = null)
+        protected static MainViewModel CreateTestMainViewModel(EnvironmentSettingsOverrides? environmentOverrides = null)
         {
             var commandParserService = new CommandParserService();
             var mqttServiceMock = Substitute.For<IMqttService>();
-            return new MainViewModel(commandParserService, mqttServiceMock, null, null, null, aspireHostname, aspirePort);
+            return new MainViewModel(commandParserService, mqttServiceMock, null, null, null, environmentOverrides);
         }
 
         /// <summary>

--- a/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
+++ b/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
@@ -1,4 +1,5 @@
 using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Configuration;
 using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.UI.ViewModels;
 using NSubstitute;
@@ -129,7 +130,7 @@ namespace CrowsNestMqtt.UnitTests.ViewModels
             const string expectedHostname = "testhost";
             const int expectedPort = 1883;
 
-            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, null, null, null, expectedHostname, expectedPort);
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, null, null, null, new EnvironmentSettingsOverrides { Hostname = expectedHostname, Port = expectedPort, HasOverrides = true, IsAspireEnvironment = true });
 
             // Act
             viewModel.ConnectCommand.Execute(System.Reactive.Unit.Default).Subscribe();

--- a/tools/SendTestData.ps1
+++ b/tools/SendTestData.ps1
@@ -3,6 +3,8 @@
 
 param(
     [string]$SettingsPath = "$env:LOCALAPPDATA\CrowsNestMqtt\settings.json",
+    [string]$Broker = "",
+    [int]$BrokerPort = 0,
     [string]$ImagePath = "",
     [string]$VideoPath = "",
     [string]$JsonPath = "",
@@ -35,8 +37,8 @@ Add-Type -Path $dllPath
 
 # Read settings
 $settings = Get-Content $SettingsPath | ConvertFrom-Json
-$mqttHost = $settings.Hostname
-$port = $settings.Port
+$mqttHost = if ($Broker) { $Broker } elseif ($settings.Hostname) { $settings.Hostname } else { "localhost" }
+$port = if ($BrokerPort -gt 0) { $BrokerPort } elseif ($settings.Port -and $settings.Port -gt 0) { $settings.Port } else { 1883 }
 $useTls = $settings.UseTls
 $clientId = "pwsh-mqtt-$(Get-Random)"
 $publishTimeout = [TimeSpan]::FromSeconds(30)
@@ -44,7 +46,7 @@ $publishTimeout = [TimeSpan]::FromSeconds(30)
 # Build MQTT client options (MQTTnet 5.x API)
 $optionsBuilder = [MQTTnet.MqttClientOptionsBuilder]::new()
 $optionsBuilder = $optionsBuilder.WithTcpServer($mqttHost, [int]$port).WithClientId($clientId)
-if ($useTls) { $optionsBuilder = $optionsBuilder.WithTls() }
+if ($useTls) { $optionsBuilder = $optionsBuilder.WithTlsOptions({ param($tlsOptions) }) }
 $options = $optionsBuilder.Build()
 
 # Create MQTT client


### PR DESCRIPTION
This pull request introduces comprehensive support for configuring the application via environment variables, with an emphasis on improved integration with dotnet Aspire and enhanced flexibility for various deployment scenarios. The changes include a new configuration class for reading and prioritizing environment variable overrides, updates to the documentation, and modifications to the application startup and view models to leverage these overrides. The environment-based configuration is now persisted, ensuring consistency across tools and environments.

**Environment Variable Configuration and Integration:**

* Introduced the `EnvironmentSettingsOverrides` class to encapsulate reading, prioritizing, and applying environment variable overrides for application settings, including support for dotnet Aspire conventions and fallback logic. This enables settings to be overridden via environment variables and persisted to `settings.json`.
* Updated the `README.md` with detailed documentation on environment variable configuration, including supported variables, priority rules, and usage examples for Aspire and manual configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L223-R229) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240-R303)

**dotnet Aspire and Application Startup:**

* Changed the Aspire container endpoint naming from `default` to `mqtt` in `src/AppHost/Program.cs`, and updated how the MQTT endpoint is referenced and passed to the client application. Default environment variables for the client are now set explicitly. [[1]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666L5-R5) [[2]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666L14-R27)
* Refactored the application startup in `src/MainApp/Program.cs` to use the new `EnvironmentSettingsOverrides` for configuration, replacing previous logic that parsed Aspire endpoints manually. [[1]](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0R9) [[2]](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0L80-R82) [[3]](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0L93-R94) [[4]](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0L121-R125) [[5]](diffhunk://#diff-461b8220979827f0a394b5340e1d494867458c99c9330ea6f738946a368486e0L200-L235)

**ViewModel and Settings Handling:**

* Updated `MainViewModel` and `SettingsViewModel` to accept and utilize the new `EnvironmentSettingsOverrides`, ensuring that all relevant settings are initialized and displayed based on environment-derived configuration. [[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR39) [[2]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR54) [[3]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL754-R756) [[4]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL770-R773)

These changes collectively make the application more robust and flexible for cloud-native, CI/CD, and local development workflows.