### PR TITLE
fix macOS DMG app executable naming and document Gatekeeper workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Add-AppxPackage -Path .\CrowsNestMqtt-1.0.0.msixbundle
 ### Linux & macOS
 Download the platform-specific archive or `.dmg` from [GitHub Releases](https://github.com/koepalex/Crow-s-Nest-MQTT/releases) and run the executable directly—no installation step required.
 
+Current macOS release artifacts are not yet Apple Developer signed/notarized. If macOS blocks app launch after copying to `/Applications`, use one of these options:
+
+1. In Finder, right-click `CrowsNestMQTT.app` and choose **Open**.
+2. If needed, remove quarantine attributes from Terminal:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/CrowsNestMQTT.app
+```
+
 ## Why using it?
 
 * Focused on developer 💻

--- a/tools/create-macos-dmg.sh
+++ b/tools/create-macos-dmg.sh
@@ -11,6 +11,22 @@ runtime="$2"
 version="$3"
 provided_executable_name="${4:-}"
 
+sanitize_macos_executable_name() {
+  local original_name="$1"
+  local sanitized_name="$original_name"
+
+  if [[ "$sanitized_name" == *.app ]]; then
+    sanitized_name="${sanitized_name%.app}"
+  fi
+
+  if [[ -z "$sanitized_name" ]]; then
+    echo "Could not derive a valid macOS executable name from: $original_name"
+    exit 1
+  fi
+
+  printf '%s' "$sanitized_name"
+}
+
 if [[ ! -d "$publish_dir" ]]; then
   echo "Publish directory does not exist: $publish_dir"
   exit 1
@@ -83,6 +99,8 @@ else
     exit 1
   fi
 
+  bundle_executable_name="$(sanitize_macos_executable_name "$executable_name")"
+
   app_name="CrowsNestMQTT.app"
   app_root="$staging_dir/$app_name"
   app_contents="$app_root/Contents"
@@ -99,7 +117,12 @@ else
     if [[ "$entry_name" == *.app ]]; then
       continue
     fi
-    cp -R "$entry" "$app_macos/$entry_name"
+    target_name="$entry_name"
+    if [[ "$entry_name" == "$executable_name" ]]; then
+      target_name="$bundle_executable_name"
+    fi
+
+    cp -R "$entry" "$app_macos/$target_name"
   done
   shopt -u nullglob dotglob
 
@@ -111,7 +134,7 @@ else
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleExecutable</key>
-  <string>${executable_name}</string>
+  <string>${bundle_executable_name}</string>
   <key>CFBundleIdentifier</key>
   <string>com.koepalex.crowsnestmqtt</string>
   <key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
This captures both the root fix (renaming CFBundleExecutable away from .app suffix) and the README update for unsigned/notarized launch behavior.