### PR TITLE
Trigger an update to koepalex/homebrew-crowsnest to automatically update homebrew to use the latest version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,3 +203,19 @@ jobs:
           ./zipped-releases/*.zip
           ./zipped-releases/*.dmg
           ./zipped-releases/*.msixbundle
+
+  bump_homebrew:
+    name: Bump Homebrew Cask
+    runs-on: ubuntu-latest
+    needs:
+      - determine_version
+      - release
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Trigger homebrew-crowsnest bump
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: koepalex/homebrew-crowsnest
+          event-type: bump-cask
+          client-payload: '{"version": "${{ needs.determine_version.outputs.semVer }}"}'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Whether you're a seasoned developer or a newcomer to IoT, Crow’s NestMQTT prov
 ### Microsoft Store (Recommended)
 Install from the Microsoft Store for the simplest experience. Packages are automatically signed by Microsoft—no additional setup required.
 
+### Homebrew (macOS)
+Install via [Homebrew](https://brew.sh/) using the custom tap:
+
+```bash
+brew tap koepalex/crowsnest
+brew install --cask crowsnestmqtt
+```
+
+To update:
+```bash
+brew upgrade --cask crowsnestmqtt
+```
+
 ### GitHub Releases (Sideloading)
 Download the `.msixbundle` or platform-specific `.msix` from [GitHub Releases](https://github.com/koepalex/Crow-s-Nest-MQTT/releases). These packages are unsigned, so Windows requires **Developer Mode** to be enabled before installation:
 
@@ -21,8 +34,8 @@ Alternatively, install via PowerShell:
 Add-AppxPackage -Path .\CrowsNestMqtt-1.0.0.msixbundle
 ```
 
-### Linux & macOS
-Download the platform-specific archive or `.dmg` from [GitHub Releases](https://github.com/koepalex/Crow-s-Nest-MQTT/releases) and run the executable directly—no installation step required.
+### Linux
+Download the platform-specific archive from [GitHub Releases](https://github.com/koepalex/Crow-s-Nest-MQTT/releases) and run the executable directly—no installation step required.
 
 ## Why using it?
 


### PR DESCRIPTION
This pull request adds official Homebrew support for macOS users and automates the process of updating the Homebrew cask when a new release is published. It also updates the documentation to reflect these changes and clarifies installation instructions for Linux and macOS.

**Homebrew support and automation:**

* Added a new `bump_homebrew` job to the GitHub Actions workflow (`.github/workflows/publish.yml`) that triggers an update to the `homebrew-crowsnest` tap via a repository dispatch event whenever a new tag is released.

**Documentation updates:**

* Updated `README.md` to include Homebrew installation and upgrade instructions for macOS users, providing a clear and recommended installation path.
* Clarified the Linux installation section in `README.md` by removing references to macOS, since macOS users are now directed to use Homebrew.