### PR TITLE
Add winget manifest bump to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -219,3 +219,19 @@ jobs:
           repository: koepalex/homebrew-crowsnest
           event-type: bump-cask
           client-payload: '{"version": "${{ needs.determine_version.outputs.semVer }}"}'
+
+  bump_winget:
+    name: Bump Winget Manifest
+    runs-on: ubuntu-latest
+    needs:
+      - determine_version
+      - release
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Trigger winget-pkgs manifest update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WINGET_PKGS_TOKEN }}
+          repository: koepalex/winget-pkgs
+          event-type: bump-winget
+          client-payload: '{"version": "${{ needs.determine_version.outputs.semVer }}"}'


### PR DESCRIPTION
Adds a bump_winget job to the publish workflow that triggers the update-manifest.yml workflow in koepalex/winget-pkgs via repository-dispatch when a tag is pushed. This mirrors the existing bump_homebrew pattern. Requires WINGET_PKGS_TOKEN secret (classic PAT with public_repo scope).