### PR TITLE
Add MQTT WebSocket transport support (ws://, wss://)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -486,3 +486,4 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 publish/msix-win-x64/
+*.lscache

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,40 +4,41 @@
     <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.2" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.2" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" Condition="'$(Configuration)' == 'Debug'" />  
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageVersion Include="Avalonia" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.18" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <PackageVersion Include="GitVersion.MsBuild" Version="6.7.0" />
-    <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageVersion Include="SharpHook" Version="5.3.9" />
-    <PackageVersion Include="SharpHook.Reactive" Version="5.3.9" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="SharpHook" Version="7.1.2" />
+    <PackageVersion Include="SharpHook.Reactive" Version="7.1.2" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageVersion Include="Avalonia.Xaml.Interactivity" Version="11.3.0.6" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
     <PackageVersion Include="FuzzySharp" Version="2.0.2" />
-    <PackageVersion Include="LibVLCSharp.Avalonia" Version="3.9.7.1" />
+    <PackageVersion Include="LibVLCSharp.Avalonia" Version="3.10.0" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.7" />
-    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="3.0.21" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="3.0.23.1" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <PackageVersion Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <PackageVersion Include="MQTTnet" Version="5.1.0.1559" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="MQTTnet.Server" Version="5.1.0.1559" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.4.12" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.5" />
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ xattr -dr com.apple.quarantine /Applications/CrowsNestMQTT.app
     * Strikethrough and dimmed text in message history for expired messages
     * Yellow warning icon in metadata view for the expiry field
 * Supports TLS connection to MQTT Broker 🔐
+* Supports WebSocket transport (ws:// and wss://) 🌐
 * Can handle huge amount of MQTT messages 
 * Allows filtering of MQTT topics by pattern 🗃️
 * Allows searching of pattern within MQTT message payloads 🔍
@@ -171,7 +172,7 @@ Messages with MQTT V5 `message-expiry-interval` are visually marked when they ex
 
 Crow's Nest MQTT provides a command interface (likely accessible via a dedicated input field) for quick actions. Commands are typically prefixed with a colon (`:`). You can quickly access this input field using the `Ctrl + Shift + P` keyboard shortcut.
 
-*   `:connect [<server:port>] [<username>] [<password>]` - Connect to an MQTT broker. If arguments are omitted, connection details are loaded from settings.
+*   `:connect [<server:port>] [<username>] [<password>]` - Connect to an MQTT broker. If arguments are omitted, connection details are loaded from settings. Supports WebSocket URIs: `:connect ws://host:port/path` or `:connect wss://host:port/path`.
 *   `:disconnect` - Disconnect from the current MQTT broker.
 *   `:export <json|txt> <filepath>` - Export messages to a file in JSON or plain text format. If arguments are omitted, the path and format are loaded from settings.
 *   `:export all` - Export all messages from the currently selected topic to a single JSON file in the configured export path. The file contains an array of all messages from that topic.
@@ -242,7 +243,11 @@ When connecting to a broker with Enhanced Authentication, the client and broker 
 
 ## dotnet Aspire
 
-Crow's NestMQTT automatically connects to the MQTT Broker endpoint defined via dotnet Aspire environment variables. It supports both `services__mqtt__mqtt__0` and `services__mqtt__default__0` naming conventions. For example, the environment variable would contain a value like `mqtt://localhost:42069`.
+Crow's NestMQTT automatically connects to the MQTT Broker endpoint defined via dotnet Aspire environment variables. It supports both `services__mqtt__mqtt__0` and `services__mqtt__default__0` naming conventions. The endpoint URI scheme determines the transport protocol:
+
+- `mqtt://localhost:1883` → TCP connection
+- `ws://localhost:8083/mqtt` → WebSocket connection
+- `wss://localhost:8084/mqtt` → Secure WebSocket connection (TLS)
 
 When an Aspire endpoint environment variable is detected, the application:
 1. Parses the hostname and port from the URI
@@ -287,6 +292,8 @@ This is useful for:
 | `CROWSNEST__AUTH_METHOD` | Enhanced auth method (when AUTH_MODE=enhanced) | string | `SCRAM-SHA-1` |
 | `CROWSNEST__AUTH_DATA` | Enhanced auth data (when AUTH_MODE=enhanced) | string | |
 | `CROWSNEST__USE_TLS` | Enable TLS encryption | bool | `true` |
+| `CROWSNEST__TRANSPORT` | Transport protocol | enum | `Tcp`, `WebSocket` |
+| `CROWSNEST__WEBSOCKET_PATH` | WebSocket path (when TRANSPORT=WebSocket) | string | `/mqtt` |
 | `CROWSNEST__SUBSCRIPTION_QOS` | Subscription QoS level (0, 1, or 2) | int | `1` |
 | `CROWSNEST__EXPORT_FORMAT` | Default export format | enum | `json`, `txt` |
 | `CROWSNEST__EXPORT_PATH` | Default export file path | string | `/tmp/exports` |
@@ -307,6 +314,26 @@ This is useful for:
 ```bash
 # Set by Aspire automatically:
 services__mqtt__mqtt__0=mqtt://localhost:41883
+
+# Or for WebSocket transport:
+services__mqtt__default__0=ws://localhost:8083/mqtt
+```
+
+### Example: WebSocket Configuration
+
+```bash
+# Connect via WebSocket
+export CROWSNEST__HOSTNAME=broker.example.com
+export CROWSNEST__PORT=8083
+export CROWSNEST__TRANSPORT=WebSocket
+export CROWSNEST__WEBSOCKET_PATH=/mqtt
+
+# Or via secure WebSocket
+export CROWSNEST__HOSTNAME=broker.example.com
+export CROWSNEST__PORT=8084
+export CROWSNEST__TRANSPORT=WebSocket
+export CROWSNEST__USE_TLS=true
+export CROWSNEST__WEBSOCKET_PATH=/mqtt
 ```
 
 ### Example: Manual Configuration

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MainApp\CrowsNestMqtt.App.csproj" />
   </ItemGroup>
 

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,23 +1,27 @@
+using Aspire.Hosting.ApplicationModel;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Add EMQX MQTT v5 broker as a Docker container with dynamic ports
 var mqttBroker = builder.AddContainer("mqtt", "emqx/emqx", "latest")
     .WithEndpoint(targetPort: 1883, name: "mqtt", scheme: "mqtt")
+    .WithEndpoint(targetPort: 8083, name: "ws", scheme: "ws")
+    .WithEndpoint(targetPort: 8883, name: "mqtts", scheme: "tcp")
     .WithHttpEndpoint(targetPort: 18083, name: "dashboard")
-    .WithEnvironment("EMQX_ALLOW_ANONYMOUS", "true")
     .WithEnvironment("EMQX_AUTHORIZATION__NO_MATCH", "allow")
     .WithEnvironment("EMQX_AUTHORIZATION__SOURCES", "[]") // Disable file-based ACL to allow subscribe to #
-    .WithEnvironment("EMQX_LISTENER__TCP__EXTERNAL", "1883")
-    .WithEnvironment("EMQX_MQTT__MAX_PACKET_SIZE", "10485760"); // 10MB max packet size
+    .WithEnvironment("EMQX_LISTENERS__TCP__DEFAULT__BIND", "0.0.0.0:1883")
+    .WithEnvironment("EMQX_LISTENERS__WS__DEFAULT__BIND", "0.0.0.0:8083")
+    .WithEnvironment("EMQX_LISTENERS__SSL__DEFAULT__BIND", "0.0.0.0:8883")
+    .WithEnvironment("EMQX_MQTT__MAX_PACKET_SIZE", "10MB");
 
-// Get the MQTT endpoint for passing to the client application
+// Get the MQTT endpoints for passing to the client applications
 var mqttEndpoint = mqttBroker.GetEndpoint("mqtt");
+var wsEndpoint = mqttBroker.GetEndpoint("ws");
+var mqttsEndpoint = mqttBroker.GetEndpoint("mqtts");
 
-// Add CrowsNestMqtt as a project that auto-connects to the MQTT broker
-builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt")
-    .WithReference(mqttEndpoint)
-    .WaitFor(mqttBroker)
-    .WithEnvironment("CROWSNEST__USE_TLS", "false")
+// Shared settings for all CrowsNestMqtt instances
+var sharedEnvVars = (IResourceBuilder<ProjectResource> rb) => rb
     .WithEnvironment("CROWSNEST__AUTH_MODE", "anonymous")
     .WithEnvironment("CROWSNEST__CLIENT_ID", "")
     .WithEnvironment("CROWSNEST__KEEP_ALIVE_SECONDS", "0")
@@ -25,5 +29,42 @@ builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt")
     .WithEnvironment("CROWSNEST__SESSION_EXPIRY_SECONDS", "0")
     .WithEnvironment("CROWSNEST__SUBSCRIPTION_QOS", "1")
     .WithEnvironment("CROWSNEST__TOPIC_BUFFER_LIMITS", """[{"TopicFilter":"#","MaxSizeBytes":11048576}]""");
+
+// Add CrowsNestMqtt as a project that auto-connects to the MQTT broker via TCP
+var tcpInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt")
+    .WithReference(mqttEndpoint)
+    .WaitFor(mqttBroker)
+    .WithEnvironment("CROWSNEST__HOSTNAME", mqttEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("CROWSNEST__PORT", mqttEndpoint.Property(EndpointProperty.Port))
+    .WithEnvironment("CROWSNEST__USE_TLS", "false");
+sharedEnvVars(tcpInstance);
+
+// Add a second CrowsNestMqtt instance that connects via WebSocket
+var wsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt-ws")
+    .WithReference(wsEndpoint)
+    .WaitFor(mqttBroker)
+    .WithEnvironment("CROWSNEST__HOSTNAME", wsEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("CROWSNEST__PORT", wsEndpoint.Property(EndpointProperty.Port))
+    .WithEnvironment("CROWSNEST__USE_TLS", "false")
+    .WithEnvironment("CROWSNEST__TRANSPORT", "WebSocket")
+    .WithEnvironment("CROWSNEST__WEBSOCKET_PATH", "/mqtt");
+sharedEnvVars(wsInstance);
+
+// Add a third CrowsNestMqtt instance that connects via TLS
+var tlsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt-tls")
+    .WithReference(mqttsEndpoint)
+    .WaitFor(mqttBroker)
+    .WithEnvironment("CROWSNEST__HOSTNAME", mqttsEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("CROWSNEST__PORT", mqttsEndpoint.Property(EndpointProperty.Port))
+    .WithEnvironment("CROWSNEST__USE_TLS", "true");
+sharedEnvVars(tlsInstance);
+
+// Add delayed test data sender that publishes sample data after broker is ready
+var toolsDir = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, "..", "..", "tools"));
+builder.AddExecutable("test-data-sender", "pwsh", toolsDir, "-File", "SendTestDataDelayed.ps1")
+    .WithReference(mqttEndpoint)
+    .WaitFor(mqttBroker)
+    .WithEnvironment("MQTT_HOST", mqttEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("MQTT_PORT", mqttEndpoint.Property(EndpointProperty.Port));
 
 builder.Build().Run();

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -65,6 +65,7 @@ builder.AddExecutable("test-data-sender", "pwsh", toolsDir, "-File", "SendTestDa
     .WithReference(mqttEndpoint)
     .WaitFor(mqttBroker)
     .WithEnvironment("MQTT_HOST", mqttEndpoint.Property(EndpointProperty.Host))
-    .WithEnvironment("MQTT_PORT", mqttEndpoint.Property(EndpointProperty.Port));
+    .WithEnvironment("MQTT_PORT", mqttEndpoint.Property(EndpointProperty.Port))
+    .WithEnvironment("MQTT_USE_TLS", "false");
 
 builder.Build().Run();

--- a/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
+++ b/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
@@ -14,8 +14,7 @@ using CrowsNestMqtt.Utils;
 public sealed record EnvironmentSettingsOverrides
 {
     private const string Prefix = "CROWSNEST__";
-    private const string AspireDefaultEnvVar = "services__mqtt__default__0";
-    private const string AspireMqttEnvVar = "services__mqtt__mqtt__0";
+    private const string AspireServicePrefix = "services__mqtt__";
 
     public string? Hostname { get; init; }
     public int? Port { get; init; }
@@ -33,6 +32,8 @@ public sealed record EnvironmentSettingsOverrides
     public int? TimeoutPeriodSeconds { get; init; }
     public long? DefaultTopicBufferSizeBytes { get; init; }
     public IList<TopicBufferLimit>? TopicSpecificBufferLimits { get; init; }
+    public TransportProtocol? Transport { get; init; }
+    public string? WebSocketPath { get; init; }
 
     /// <summary>
     /// Whether any environment variable overrides were detected.
@@ -53,17 +54,23 @@ public sealed record EnvironmentSettingsOverrides
         string? hostname = null;
         int? port = null;
         bool isAspire = false;
+        TransportProtocol? transport = null;
+        bool? useTlsFromUri = null;
+        string? webSocketPath = null;
 
         // Check Aspire endpoint env vars (lower priority than explicit CROWSNEST__ vars)
-        var aspireEndpoint = Environment.GetEnvironmentVariable(AspireMqttEnvVar)
-                          ?? Environment.GetEnvironmentVariable(AspireDefaultEnvVar);
+        // Aspire sets services__mqtt__<endpoint-name>__0 for each referenced endpoint
+        var aspireEndpoint = FindAspireEndpointVar();
 
         if (!string.IsNullOrEmpty(aspireEndpoint))
         {
             isAspire = true;
-            var (aspireHost, aspirePort) = ParseMqttUri(aspireEndpoint);
-            hostname = aspireHost;
-            port = aspirePort;
+            var parsed = ParseMqttUri(aspireEndpoint);
+            hostname = parsed.hostname;
+            port = parsed.port;
+            transport = parsed.transport;
+            useTlsFromUri = parsed.useTls;
+            webSocketPath = parsed.webSocketPath;
         }
 
         // Read individual CROWSNEST__ env vars (these override Aspire values)
@@ -83,20 +90,28 @@ public sealed record EnvironmentSettingsOverrides
         var defaultBufferSize = ReadLong("DEFAULT_BUFFER_SIZE_BYTES");
         var topicLimits = ReadTopicBufferLimits("TOPIC_BUFFER_LIMITS");
         var authMode = ReadAuthMode();
+        var envTransport = ReadTransport("TRANSPORT");
+        var envWebSocketPath = ReadString("WEBSOCKET_PATH");
 
         // Explicit CROWSNEST__ hostname/port override Aspire-derived values
         if (envHostname != null) hostname = envHostname;
         if (envPort.HasValue) port = envPort;
+        if (envTransport.HasValue) transport = envTransport;
+        if (envWebSocketPath != null) webSocketPath = envWebSocketPath;
+
+        // Explicit USE_TLS overrides URI-derived value
+        var finalUseTls = useTls ?? useTlsFromUri;
 
         bool hasAny = isAspire
             || envHostname != null || envPort.HasValue
             || clientId != null || keepAlive.HasValue
             || cleanSession.HasValue || sessionExpiry.HasValue
-            || useTls.HasValue || subscriptionQoS.HasValue
+            || finalUseTls.HasValue || subscriptionQoS.HasValue
             || exportFormat.HasValue || exportPath != null
             || maxTopicLimit.HasValue || parallelismDegree.HasValue
             || timeoutSeconds.HasValue || defaultBufferSize.HasValue
-            || topicLimits != null || authMode != null;
+            || topicLimits != null || authMode != null
+            || transport.HasValue || webSocketPath != null;
 
         if (hasAny)
         {
@@ -112,7 +127,7 @@ public sealed record EnvironmentSettingsOverrides
             CleanSession = cleanSession,
             SessionExpiryIntervalSeconds = sessionExpiry,
             AuthMode = authMode,
-            UseTls = useTls,
+            UseTls = finalUseTls,
             SubscriptionQoS = subscriptionQoS,
             ExportFormat = exportFormat,
             ExportPath = exportPath,
@@ -121,19 +136,39 @@ public sealed record EnvironmentSettingsOverrides
             TimeoutPeriodSeconds = timeoutSeconds,
             DefaultTopicBufferSizeBytes = defaultBufferSize,
             TopicSpecificBufferLimits = topicLimits,
+            Transport = transport,
+            WebSocketPath = webSocketPath,
             HasOverrides = hasAny,
             IsAspireEnvironment = isAspire
         };
     }
 
-    internal static (string? hostname, int? port) ParseMqttUri(string connectionString)
+    internal static (string? hostname, int? port, TransportProtocol? transport, bool? useTls, string? webSocketPath) ParseMqttUri(string connectionString)
     {
         try
         {
             var uri = new Uri(connectionString);
             if (!string.IsNullOrEmpty(uri.Host) && uri.Port > 0)
             {
-                return (uri.Host, uri.Port);
+                var scheme = uri.Scheme.ToLowerInvariant();
+                TransportProtocol? transport = scheme switch
+                {
+                    "ws" or "wss" => TransportProtocol.WebSocket,
+                    "mqtt" or "mqtts" or "tcp" => TransportProtocol.Tcp,
+                    _ => null
+                };
+                bool? useTls = scheme switch
+                {
+                    "wss" or "mqtts" => true,
+                    "ws" or "mqtt" or "tcp" => false,
+                    _ => null
+                };
+                // Extract WebSocket path (use null if root or empty)
+                string? wsPath = transport == TransportProtocol.WebSocket && uri.AbsolutePath != "/"
+                    ? uri.AbsolutePath
+                    : null;
+
+                return (uri.Host, uri.Port, transport, useTls, wsPath);
             }
         }
         catch (UriFormatException ex)
@@ -141,7 +176,7 @@ public sealed record EnvironmentSettingsOverrides
             AppLogger.Error(ex, "Invalid URI format for MQTT connection string: {ConnectionString}", connectionString);
         }
 
-        return (null, null);
+        return (null, null, null, null, null);
     }
 
     private static AuthenticationMode? ReadAuthMode()
@@ -230,5 +265,42 @@ public sealed record EnvironmentSettingsOverrides
             AppLogger.Error(ex, "Failed to parse {EnvVar} environment variable as JSON", Prefix + name);
             return null;
         }
+    }
+
+    private static TransportProtocol? ReadTransport(string name)
+    {
+        var value = ReadString(name);
+        if (value != null && Enum.TryParse<TransportProtocol>(value, ignoreCase: true, out var result))
+            return result;
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the first Aspire service endpoint env var matching services__mqtt__*__0.
+    /// Aspire sets these based on the endpoint name (e.g., services__mqtt__mqtt__0, services__mqtt__ws__0).
+    /// Prefers "mqtt" endpoint, then "default", then any other.
+    /// </summary>
+    private static string? FindAspireEndpointVar()
+    {
+        // Check well-known names first for deterministic priority
+        var mqtt = Environment.GetEnvironmentVariable(AspireServicePrefix + "mqtt__0");
+        if (!string.IsNullOrEmpty(mqtt)) return mqtt;
+
+        var defaultVar = Environment.GetEnvironmentVariable(AspireServicePrefix + "default__0");
+        if (!string.IsNullOrEmpty(defaultVar)) return defaultVar;
+
+        // Fall back to scanning for any services__mqtt__*__0 pattern
+        var envVars = Environment.GetEnvironmentVariables();
+        foreach (System.Collections.DictionaryEntry entry in envVars)
+        {
+            var key = entry.Key?.ToString();
+            if (key != null
+                && key.StartsWith(AspireServicePrefix, StringComparison.OrdinalIgnoreCase)
+                && key.EndsWith("__0", StringComparison.Ordinal))
+            {
+                return entry.Value?.ToString();
+            }
+        }
+        return null;
     }
 }

--- a/src/BusinessLogic/Configutation/SettingsData.cs
+++ b/src/BusinessLogic/Configutation/SettingsData.cs
@@ -17,7 +17,9 @@ public record SettingsData(
     int MaxTopicLimit = 500,
     int ParallelismDegree = 4,
     int TimeoutPeriodSeconds = 5,
-    int SubscriptionQoS = 1)
+    int SubscriptionQoS = 1,
+    TransportProtocol Transport = TransportProtocol.Tcp,
+    string? WebSocketPath = null)
 {
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; init; } = new List<TopicBufferLimit>();
     /// <summary>

--- a/src/BusinessLogic/Configutation/TransportProtocol.cs
+++ b/src/BusinessLogic/Configutation/TransportProtocol.cs
@@ -1,0 +1,17 @@
+namespace CrowsNestMqtt.BusinessLogic.Configuration;
+
+/// <summary>
+/// Specifies the transport protocol used to connect to an MQTT broker.
+/// </summary>
+public enum TransportProtocol
+{
+    /// <summary>
+    /// Standard TCP connection (default).
+    /// </summary>
+    Tcp = 0,
+
+    /// <summary>
+    /// WebSocket connection (ws:// or wss:// with TLS).
+    /// </summary>
+    WebSocket = 1
+}

--- a/src/BusinessLogic/MqttConnectionSettings.cs
+++ b/src/BusinessLogic/MqttConnectionSettings.cs
@@ -25,6 +25,15 @@ public class MqttConnectionSettings
     public AuthenticationMode AuthMode { get; set; } = new AnonymousAuthenticationMode();
     public bool UseTls { get; set; } = false;
     /// <summary>
+    /// Transport protocol to use for the MQTT connection. Default is TCP.
+    /// </summary>
+    public TransportProtocol Transport { get; set; } = TransportProtocol.Tcp;
+    /// <summary>
+    /// WebSocket path when using WebSocket transport. Defaults to "/mqtt" if not specified.
+    /// Only used when <see cref="Transport"/> is <see cref="TransportProtocol.WebSocket"/>.
+    /// </summary>
+    public string? WebSocketPath { get; set; }
+    /// <summary>
     /// QoS level for the wildcard subscription. Default is 1 (AtLeastOnce).
     /// Set to 2 (ExactlyOnce) if you need to receive QoS 2 messages without downgrade.
     /// Higher QoS reduces maximum message throughput.

--- a/src/BusinessLogic/MqttEngine.cs
+++ b/src/BusinessLogic/MqttEngine.cs
@@ -179,12 +179,24 @@ private MqttClientOptions? _currentOptions;
     private MqttClientOptions BuildMqttOptions()
     {
         var builder = new MqttClientOptionsBuilder()
-            .WithTcpServer(_settings.Hostname, _settings.Port)
             .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
             .WithKeepAlivePeriod(_settings.KeepAliveInterval)
             .WithCleanSession(_settings.CleanSession)
             .WithWillQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
             .WithTimeout(TimeSpan.FromSeconds(10));
+
+        // Configure transport
+        if (_settings.Transport == TransportProtocol.WebSocket)
+        {
+            var scheme = _settings.UseTls ? "wss" : "ws";
+            var path = string.IsNullOrWhiteSpace(_settings.WebSocketPath) ? "/mqtt" : _settings.WebSocketPath;
+            var uri = $"{scheme}://{_settings.Hostname}:{_settings.Port}{path}";
+            builder.WithWebSocketServer(o => o.WithUri(uri));
+        }
+        else
+        {
+            builder.WithTcpServer(_settings.Hostname, _settings.Port);
+        }
 
         if (_settings.SessionExpiryInterval.HasValue)
         {

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -30,7 +30,7 @@ using CrowsNestMqtt.Utils; // Added for AppLogger
 using DynamicData; // Added for SourceList and reactive filtering
 using DynamicData.Binding; // Added for Bind()
 using FuzzySharp; // Added for fuzzy search
-using SharpHook.Native; // Added SharpHook Native for KeyCode and ModifierMask
+using SharpHook.Data; // SharpHook 7.x: KeyCode and EventMask live in SharpHook.Data (formerly SharpHook.Native / ModifierMask)
 using SharpHook.Reactive; // Added SharpHook Reactive
 using System.Reactive.Concurrency;
 using System.Linq;
@@ -1128,13 +1128,13 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
         {
             try
             {
-                _globalHook = new SimpleReactiveGlobalHook();
+                _globalHook = new ReactiveGlobalHook();
                 _globalHookSubscription = _globalHook.KeyPressed
                     .Do(e => { })
                     .Where(e =>
                     {
-                        bool ctrl = e.RawEvent.Mask.HasFlag(ModifierMask.LeftCtrl) || e.RawEvent.Mask.HasFlag(ModifierMask.RightCtrl);
-                        bool shift = e.RawEvent.Mask.HasFlag(ModifierMask.LeftShift) || e.RawEvent.Mask.HasFlag(ModifierMask.RightShift);
+                        bool ctrl = e.RawEvent.Mask.HasFlag(EventMask.LeftCtrl) || e.RawEvent.Mask.HasFlag(EventMask.RightCtrl);
+                        bool shift = e.RawEvent.Mask.HasFlag(EventMask.LeftShift) || e.RawEvent.Mask.HasFlag(EventMask.RightShift);
                         bool pKey = e.Data.KeyCode == KeyCode.VcP;
                         bool focused = IsWindowFocused;
                         bool match = focused && ctrl && shift && pKey;
@@ -1154,11 +1154,23 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
                     .Select(_ => Unit.Default)
                     .InvokeCommand(FocusCommandBarCommand);
 
-                _globalHook.RunAsync().Subscribe(
-                    _ => { },
-                    ex => Log.Error(ex, "Error during Global Hook execution (RunAsync OnError)"),
-                    () => Log.Information("Global Hook stopped.")
-                );
+                // SharpHook 7.x: RunAsync now returns a Task instead of IObservable<Unit>.
+                // Observe completion/failure with ContinueWith so the hook lifecycle is still logged.
+                _ = _globalHook.RunAsync().ContinueWith(t =>
+                {
+                    if (t.IsFaulted && t.Exception is { } ex)
+                    {
+                        Log.Error(ex.GetBaseException(), "Error during Global Hook execution (RunAsync faulted).");
+                    }
+                    else if (t.IsCanceled)
+                    {
+                        Log.Information("Global Hook canceled.");
+                    }
+                    else
+                    {
+                        Log.Information("Global Hook stopped.");
+                    }
+                }, TaskScheduler.Default);
                 Log.Information("SharpHook Global Hook RunAsync called.");
             }
             catch (Exception ex)

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -1048,7 +1048,9 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
             DefaultTopicBufferSizeBytes = Settings.Into().DefaultTopicBufferSizeBytes,
             AuthMode = Settings.Into().AuthMode,
             UseTls = Settings.UseTls,
-            SubscriptionQoS = Settings.SubscriptionQoS
+            SubscriptionQoS = Settings.SubscriptionQoS,
+            Transport = Settings.SelectedTransport,
+            WebSocketPath = Settings.WebSocketPath
         });
 
         _mqttService.ConnectionStateChanged += OnConnectionStateChanged;
@@ -2466,7 +2468,9 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             DefaultTopicBufferSizeBytes = Settings.Into().DefaultTopicBufferSizeBytes,
             AuthMode = Settings.Into().AuthMode,
             UseTls = Settings.UseTls,
-            SubscriptionQoS = Settings.SubscriptionQoS
+            SubscriptionQoS = Settings.SubscriptionQoS,
+            Transport = Settings.SelectedTransport,
+            WebSocketPath = Settings.WebSocketPath
         };
         
         _mqttService.UpdateSettings(connectionSettings);
@@ -3265,13 +3269,48 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         }
         else if (command.Arguments.Count == 1)
         {
-            // :connect server:port
+            // :connect server:port or :connect ws://server:port/path or :connect wss://server:port/path
+            var arg = command.Arguments[0];
+
+            // Check for WebSocket URI scheme
+            if (arg.StartsWith("ws://", StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith("wss://", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var uri = new Uri(arg);
+                    var scheme = uri.Scheme.ToLowerInvariant();
+                    Settings.Hostname = uri.Host;
+                    Settings.Port = uri.Port > 0 ? uri.Port : (scheme == "wss" ? 443 : 80);
+                    Settings.SelectedTransport = BusinessLogic.Configuration.TransportProtocol.WebSocket;
+                    Settings.UseTls = scheme == "wss";
+                    Settings.WebSocketPath = uri.AbsolutePath == "/" ? null : uri.AbsolutePath;
+                }
+                catch (UriFormatException)
+                {
+                    StatusBarText = $"Error: Invalid WebSocket URI '{arg}'. Expected: ws://host:port/path or wss://host:port/path";
+                    Log.Warning("Invalid WebSocket URI for :connect argument: {Argument}", arg);
+                    return;
+                }
+
+                StatusBarText = $"Attempting WebSocket connection to {Settings.Hostname}:{Settings.Port}...";
+                ConnectCommand.Execute().Subscribe(
+                    _ => StatusBarText = $"Successfully initiated WebSocket connection to {Settings.Hostname}:{Settings.Port}.",
+                    ex =>
+                    {
+                        StatusBarText = $"Error initiating connection: {ex.Message}";
+                        Log.Error(ex, "Error executing ConnectCommand");
+                    });
+                return;
+            }
+
+            // :connect server:port (TCP)
             // Parse server:port from first argument (already validated by parser)
-            var parts = command.Arguments[0].Split(':');
+            var parts = arg.Split(':');
             if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || !int.TryParse(parts[1], out int port) || port < 1 || port > 65535)
             {
-                StatusBarText = $"Error: Invalid format for :connect argument '{command.Arguments[0]}'. Expected: <server_address:port>";
-                Log.Warning("Invalid format for :connect argument: {Argument}", command.Arguments[0]);
+                StatusBarText = $"Error: Invalid format for :connect argument '{arg}'. Expected: <server_address:port> or ws://host:port/path";
+                Log.Warning("Invalid format for :connect argument: {Argument}", arg);
                 return;
             }
             string host = parts[0];

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -25,6 +25,7 @@ using System.Linq; // For .Select
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.EnhancedAuthenticationMode))] // Added for AuthMode
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Exporter.ExportTypes))]
 [JsonSerializable(typeof(Nullable<CrowsNestMqtt.BusinessLogic.Exporter.ExportTypes>))]
+[JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.TransportProtocol))]
 [JsonSerializable(typeof(ObservableCollection<TopicBufferLimitViewModel>))]
 [JsonSerializable(typeof(TopicBufferLimitViewModel))]
 [JsonSerializable(typeof(TopicBufferLimit))]
@@ -78,6 +79,35 @@ public class SettingsViewModel : ReactiveObject
     {
         get => _useTls;
         set => this.RaiseAndSetIfChanged(ref _useTls, value);
+    }
+
+    private TransportProtocol _selectedTransport = TransportProtocol.Tcp;
+    public TransportProtocol SelectedTransport
+    {
+        get => _selectedTransport;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedTransport, value);
+            this.RaisePropertyChanged(nameof(IsWebSocketSelected));
+        }
+    }
+
+    /// <summary>
+    /// Whether WebSocket transport is currently selected (for UI visibility binding).
+    /// </summary>
+    public bool IsWebSocketSelected => SelectedTransport == TransportProtocol.WebSocket;
+
+    private readonly ReadOnlyObservableCollection<TransportProtocol> _availableTransports;
+    public ReadOnlyObservableCollection<TransportProtocol> AvailableTransports => _availableTransports;
+
+    private string? _webSocketPath;
+    /// <summary>
+    /// WebSocket path (e.g., "/mqtt"). Only used when transport is WebSocket.
+    /// </summary>
+    public string? WebSocketPath
+    {
+        get => _webSocketPath;
+        set => this.RaiseAndSetIfChanged(ref _webSocketPath, value);
     }
 
     private int _subscriptionQoS = 1;
@@ -138,6 +168,12 @@ public class SettingsViewModel : ReactiveObject
             this.WhenAnyValue(x => x.SubscriptionQoS),
             (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
 
+        // Observable for transport-related property changes
+        var transportPropertiesChanged = Observable.CombineLatest(
+            this.WhenAnyValue(x => x.SelectedTransport),
+            this.WhenAnyValue(x => x.WebSocketPath),
+            (_, _) => Unit.Default);
+
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
             h => TopicSpecificLimits.CollectionChanged += h,
@@ -170,6 +206,7 @@ public class SettingsViewModel : ReactiveObject
         // Merge all change signals
         Observable.Merge(
                 simplePropertiesChanged,
+                transportPropertiesChanged,
                 collectionChanged,
                 itemPropertiesChanged.StartWith(Unit.Default) // StartWith to ensure initial state is considered if items exist
             )
@@ -194,6 +231,9 @@ public class SettingsViewModel : ReactiveObject
                 AuthModeSelection.UsernamePassword,
                 AuthModeSelection.Enhanced
             });
+
+        _availableTransports = new ReadOnlyObservableCollection<TransportProtocol>(
+            new ObservableCollection<TransportProtocol>(Enum.GetValues(typeof(TransportProtocol)).Cast<TransportProtocol>()));
     }
 
     private string _hostname = "localhost";
@@ -337,7 +377,9 @@ public class SettingsViewModel : ReactiveObject
             ExportFormat,
             ExportPath,
             UseTls,
-            SubscriptionQoS: SubscriptionQoS
+            SubscriptionQoS: SubscriptionQoS,
+            Transport: SelectedTransport,
+            WebSocketPath: WebSocketPath
         )
         {
             TopicSpecificBufferLimits = topicLimits
@@ -356,6 +398,8 @@ public class SettingsViewModel : ReactiveObject
         ExportPath = settingsData.ExportPath;
         UseTls = settingsData.UseTls;
         SubscriptionQoS = settingsData.SubscriptionQoS;
+        SelectedTransport = settingsData.Transport;
+        WebSocketPath = settingsData.WebSocketPath;
         TopicSpecificLimits.Clear();
         
         // Ensure we always have the default '#' limit
@@ -421,6 +465,8 @@ public class SettingsViewModel : ReactiveObject
         if (overrides.SubscriptionQoS.HasValue) SubscriptionQoS = overrides.SubscriptionQoS.Value;
         if (overrides.ExportFormat.HasValue) ExportFormat = overrides.ExportFormat.Value;
         if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
+        if (overrides.Transport.HasValue) SelectedTransport = overrides.Transport.Value;
+        if (overrides.WebSocketPath != null) WebSocketPath = overrides.WebSocketPath;
 
         if (overrides.AuthMode != null)
         {

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -441,7 +441,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 21 rows (0-20) for Application Settings -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 23 rows (0-22) for Application Settings -->
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -477,58 +477,72 @@
                 <TextBlock Grid.Row="3" Grid.Column="0" Text="Use TLS:"/>
                 <CheckBox Grid.Row="3" Grid.Column="1" IsChecked="{Binding Settings.UseTls, Mode=TwoWay}" Margin="10,0,0,0"/>
 
+                <!-- Transport Protocol -->
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Transport:"/>
+                <ComboBox Grid.Row="4" Grid.Column="1"
+                            ItemsSource="{Binding Settings.AvailableTransports}"
+                            SelectedItem="{Binding Settings.SelectedTransport, Mode=TwoWay}"
+                            MinWidth="220"/>
+
+                <!-- WebSocket Path (Conditionally Visible) -->
+                <TextBlock Grid.Row="5" Grid.Column="0" Text="WS Path:" IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+                <TextBox Grid.Row="5" Grid.Column="1"
+                         Text="{Binding Settings.WebSocketPath, Mode=TwoWay}"
+                         PlaceholderText="/mqtt"
+                         IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+
                 <!-- Client ID -->
-                <TextBlock Grid.Row="4" Grid.Column="0" Text="Client ID:"/>
-                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" PlaceholderText="(auto-generated)"/>
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="Client ID:"/>
+                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" PlaceholderText="(auto-generated)"/>
 
                 <!-- Keep Alive -->
-                <TextBlock Grid.Row="5" Grid.Column="0" Text="Keep Alive (s):"/>
-                <NumericUpDown Grid.Row="5" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
+                <TextBlock Grid.Row="7" Grid.Column="0" Text="Keep Alive (s):"/>
+                <NumericUpDown Grid.Row="7" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
                 
                 <!-- Clean Session -->
-                <TextBlock Grid.Row="6" Grid.Column="0" Text="Clean Session:"/>
-                <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
+                <TextBlock Grid.Row="8" Grid.Column="0" Text="Clean Session:"/>
+                <CheckBox Grid.Row="8" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
 
                 <!-- Session Expiry -->
-                <TextBlock Grid.Row="7" Grid.Column="0" Text="Session Expiry (s):"/>
-                <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Vertical" Spacing="5">
+                <TextBlock Grid.Row="9" Grid.Column="0" Text="Session Expiry (s):"/>
+                <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Vertical" Spacing="5">
                     <NumericUpDown Value="{Binding Settings.SessionExpiryIntervalSeconds, Mode=TwoWay}" MinWidth="120"  FormatString="N0" Minimum="0" PlaceholderText="(infinite)"/>
                     <TextBlock Text="(0 = expires immediately, empty = infinite)" FontSize="10"/>
                 </StackPanel>
 
                 <!-- Authentication Mode -->
-                <TextBlock Grid.Row="8" Grid.Column="0" Text="Auth Mode:"/>
-                <ComboBox Grid.Row="8" Grid.Column="1"
+                <TextBlock Grid.Row="10" Grid.Column="0" Text="Auth Mode:"/>
+                <ComboBox Grid.Row="10" Grid.Column="1"
                             ItemsSource="{Binding Settings.AvailableAuthenticationModes}"
                             SelectedItem="{Binding Settings.SelectedAuthMode, Mode=TwoWay}"
                             MinWidth="220"/>
 
                 <!-- Auth Username (Conditionally Visible) -->
-                <TextBlock Grid.Row="9" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox Grid.Row="9" Grid.Column="1"
+                <TextBlock Grid.Row="11" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox Grid.Row="11" Grid.Column="1"
                          Text="{Binding Settings.AuthUsername, Mode=TwoWay}"
                          PlaceholderText="Enter username"
                          IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
 
                 <!-- Auth Password (Conditionally Visible) -->
-                <TextBlock Grid.Row="10" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox  Grid.Row="10" Grid.Column="1"
+                <TextBlock Grid.Row="12" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox  Grid.Row="12" Grid.Column="1"
                              Text="{Binding Settings.AuthPassword, Mode=TwoWay}"
                              PlaceholderText="Enter password" PasswordChar="*"
                              IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
                 
                 <!-- Enhanced Authentication Header -->
-                <TextBlock Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Method -->
-                <TextBlock Grid.Row="12" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
-                <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" PlaceholderText="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="14" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" PlaceholderText="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Data -->
-                <TextBlock Grid.Row="13" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="15" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
                 
                 <ScrollViewer                            
-                            Grid.Row="13"
+                            Grid.Row="15"
                             Grid.Column="1"
                             IsVisible="{Binding Settings.IsEnhancedAuthSelected}"
                             HorizontalScrollBarVisibility="Visible"
@@ -546,22 +560,22 @@
                 </ScrollViewer>
 
                 <!-- General Settings Header -->
-                <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Export Format -->
-                <TextBlock Grid.Row="15" Grid.Column="0" Text="Export Format:"/>
-                <ComboBox Grid.Row="15" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
+                <TextBlock Grid.Row="17" Grid.Column="0" Text="Export Format:"/>
+                <ComboBox Grid.Row="17" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
 
                 <!-- Export Path -->
-                <TextBlock Grid.Row="16" Grid.Column="0" Text="Export Path:"/>
-                <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
+                <TextBlock Grid.Row="18" Grid.Column="0" Text="Export Path:"/>
+                <TextBox Grid.Row="18" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
 
                 <!-- Application Settings Header -->
-                <TextBlock Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Subscription QoS -->
-                <TextBlock Grid.Row="18" Grid.Column="0" Text="Subscription QoS:"/>
-                <Grid Grid.Row="18" Grid.Column="1" RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="20" Grid.Column="0" Text="Subscription QoS:"/>
+                <Grid Grid.Row="20" Grid.Column="1" RowDefinitions="Auto,Auto">
                     <ComboBox Grid.Row="0" SelectedIndex="{Binding Settings.SubscriptionQoS, Mode=TwoWay}" MinWidth="120">
                         <ComboBoxItem Content="0 - At Most Once"/>
                         <ComboBoxItem Content="1 - At Least Once (Default)"/>
@@ -571,7 +585,7 @@
                 </Grid>
 
                 <!-- Topic Buffer Limits List -->
-                <ItemsControl Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
+                <ItemsControl Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:TopicBufferLimitViewModel}">
                             <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto" Margin="0,2">
@@ -584,7 +598,7 @@
                 </ItemsControl>
                 
                 <!-- Add New Limit Button -->
-                <Button Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                <Button Grid.Row="22" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -314,4 +314,98 @@ public class MqttEngineTests
         Assert.True(sizeAfterExpand > 8_000, $"Buffer should have grown beyond previous 8K limit after expansion, was {sizeAfterExpand}");
         Assert.True(sizeAfterExpand <= 20_000, $"Buffer should not exceed new 20K limit, was {sizeAfterExpand}");
     }
+
+    [Fact]
+    public void BuildMqttOptions_WithWebSocketTransport_ShouldUseWebSocketChannel()
+    {
+        // Arrange
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "broker.example.com",
+            Port = 8083,
+            Transport = TransportProtocol.WebSocket,
+            WebSocketPath = "/mqtt"
+        };
+        using var engine = new MqttEngine(settings);
+
+        // Act
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<MqttClientWebSocketOptions>(options.ChannelOptions);
+        var wsOptions = (MqttClientWebSocketOptions)options.ChannelOptions;
+        Assert.Equal("ws://broker.example.com:8083/mqtt", wsOptions.Uri);
+    }
+
+    [Fact]
+    public void BuildMqttOptions_WithWebSocketAndTls_ShouldUseWssScheme()
+    {
+        // Arrange
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "secure.broker.io",
+            Port = 8084,
+            Transport = TransportProtocol.WebSocket,
+            UseTls = true,
+            WebSocketPath = "/mqtt"
+        };
+        using var engine = new MqttEngine(settings);
+
+        // Act
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<MqttClientWebSocketOptions>(options.ChannelOptions);
+        var wsOptions = (MqttClientWebSocketOptions)options.ChannelOptions;
+        Assert.Equal("wss://secure.broker.io:8084/mqtt", wsOptions.Uri);
+    }
+
+    [Fact]
+    public void BuildMqttOptions_WithWebSocketAndNoPath_ShouldDefaultToMqttPath()
+    {
+        // Arrange
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "broker.local",
+            Port = 8083,
+            Transport = TransportProtocol.WebSocket,
+            WebSocketPath = null
+        };
+        using var engine = new MqttEngine(settings);
+
+        // Act
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<MqttClientWebSocketOptions>(options.ChannelOptions);
+        var wsOptions = (MqttClientWebSocketOptions)options.ChannelOptions;
+        Assert.Equal("ws://broker.local:8083/mqtt", wsOptions.Uri);
+    }
+
+    [Fact]
+    public void BuildMqttOptions_WithTcpTransport_ShouldUseTcpChannel()
+    {
+        // Arrange
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "broker.local",
+            Port = 1883,
+            Transport = TransportProtocol.Tcp
+        };
+        using var engine = new MqttEngine(settings);
+
+        // Act
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<MqttClientTcpOptions>(options.ChannelOptions);
+    }
 }

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -218,25 +218,154 @@ namespace CrowsNestMqtt.UnitTests
         [Fact]
         public void ParseMqttUri_ValidUri_ReturnsHostAndPort()
         {
-            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://localhost:41883");
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://localhost:41883");
             Assert.Equal("localhost", host);
             Assert.Equal(41883, port);
+            Assert.Equal(TransportProtocol.Tcp, transport);
+            Assert.Equal(false, useTls);
+            Assert.Null(wsPath);
         }
 
         [Fact]
         public void ParseMqttUri_EmptyHost_ReturnsNull()
         {
-            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://:1883");
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("mqtt://:1883");
             Assert.Null(host);
             Assert.Null(port);
+            Assert.Null(transport);
+            Assert.Null(useTls);
+            Assert.Null(wsPath);
         }
 
         [Fact]
         public void ParseMqttUri_InvalidUri_ReturnsNull()
         {
-            var (host, port) = EnvironmentSettingsOverrides.ParseMqttUri("not a uri at all");
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("not a uri at all");
             Assert.Null(host);
             Assert.Null(port);
+            Assert.Null(transport);
+            Assert.Null(useTls);
+            Assert.Null(wsPath);
+        }
+
+        [Fact]
+        public void ParseMqttUri_WebSocketUri_ReturnsWebSocketTransport()
+        {
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("ws://broker.example.com:8083/mqtt");
+            Assert.Equal("broker.example.com", host);
+            Assert.Equal(8083, port);
+            Assert.Equal(TransportProtocol.WebSocket, transport);
+            Assert.Equal(false, useTls);
+            Assert.Equal("/mqtt", wsPath);
+        }
+
+        [Fact]
+        public void ParseMqttUri_SecureWebSocketUri_ReturnsTlsEnabled()
+        {
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("wss://secure.broker.io:8084/mqtt");
+            Assert.Equal("secure.broker.io", host);
+            Assert.Equal(8084, port);
+            Assert.Equal(TransportProtocol.WebSocket, transport);
+            Assert.Equal(true, useTls);
+            Assert.Equal("/mqtt", wsPath);
+        }
+
+        [Fact]
+        public void ParseMqttUri_WebSocketUriWithRootPath_ReturnsNullPath()
+        {
+            var (host, port, transport, useTls, wsPath) = EnvironmentSettingsOverrides.ParseMqttUri("ws://broker.local:8083/");
+            Assert.Equal("broker.local", host);
+            Assert.Equal(8083, port);
+            Assert.Equal(TransportProtocol.WebSocket, transport);
+            Assert.Equal(false, useTls);
+            Assert.Null(wsPath);
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_ParsesWebSocketAspireEndpoint()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "ws://ws.broker:8083/mqtt");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.HasOverrides);
+                Assert.True(result.IsAspireEnvironment);
+                Assert.Equal("ws.broker", result.Hostname);
+                Assert.Equal(8083, result.Port);
+                Assert.Equal(TransportProtocol.WebSocket, result.Transport);
+                Assert.Equal(false, result.UseTls);
+                Assert.Equal("/mqtt", result.WebSocketPath);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_TransportEnvVarOverridesAspireScheme()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", "mqtt://broker:1883");
+                Environment.SetEnvironmentVariable("CROWSNEST__TRANSPORT", "WebSocket");
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PATH", "/ws");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.Equal(TransportProtocol.WebSocket, result.Transport);
+                Assert.Equal("/ws", result.WebSocketPath);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__default__0", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__TRANSPORT", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PATH", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_DetectsWsEndpointName()
+        {
+            // Aspire sets services__mqtt__ws__0 when referencing a "ws" named endpoint
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__ws__0", "ws://ws.host:8083/mqtt");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.IsAspireEnvironment);
+                Assert.Equal("ws.host", result.Hostname);
+                Assert.Equal(8083, result.Port);
+                Assert.Equal(TransportProtocol.WebSocket, result.Transport);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__ws__0", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_DetectsMqttsEndpointName()
+        {
+            // Aspire sets services__mqtt__mqtts__0 when referencing a "mqtts" named endpoint
+            try
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtts__0", "tcp://tls.host:8883");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.IsAspireEnvironment);
+                Assert.Equal("tls.host", result.Hostname);
+                Assert.Equal(8883, result.Port);
+                Assert.Equal(TransportProtocol.Tcp, result.Transport);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("services__mqtt__mqtts__0", null);
+            }
         }
 
         [Fact]

--- a/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -145,4 +145,50 @@ public class SettingsViewModelTests
         var vm = new SettingsViewModel { SubscriptionQoS = input };
         Assert.Equal(expected, vm.SubscriptionQoS);
     }
+
+    [Fact]
+    public void Into_SettingsData_HasCorrectTransport()
+    {
+        var vm = new SettingsViewModel();
+        vm.SelectedTransport = TransportProtocol.WebSocket;
+        vm.WebSocketPath = "/mqtt";
+        var settingsData = vm.Into();
+        Assert.Equal(TransportProtocol.WebSocket, settingsData.Transport);
+        Assert.Equal("/mqtt", settingsData.WebSocketPath);
+    }
+
+    [Fact]
+    public void From_SettingsData_SetsTransport()
+    {
+        var settingsData = new SettingsData("host", 8083, Transport: TransportProtocol.WebSocket, WebSocketPath: "/ws");
+        var vm = new SettingsViewModel();
+        vm.From(settingsData);
+        Assert.Equal(TransportProtocol.WebSocket, vm.SelectedTransport);
+        Assert.Equal("/ws", vm.WebSocketPath);
+        Assert.True(vm.IsWebSocketSelected);
+    }
+
+    [Fact]
+    public void SettingsData_Transport_DefaultsToTcp()
+    {
+        var data = new SettingsData("host", 1883);
+        Assert.Equal(TransportProtocol.Tcp, data.Transport);
+        Assert.Null(data.WebSocketPath);
+    }
+
+    [Fact]
+    public void IsWebSocketSelected_IsFalse_WhenTransportIsTcp()
+    {
+        var vm = new SettingsViewModel();
+        vm.SelectedTransport = TransportProtocol.Tcp;
+        Assert.False(vm.IsWebSocketSelected);
+    }
+
+    [Fact]
+    public void IsWebSocketSelected_IsTrue_WhenTransportIsWebSocket()
+    {
+        var vm = new SettingsViewModel();
+        vm.SelectedTransport = TransportProtocol.WebSocket;
+        Assert.True(vm.IsWebSocketSelected);
+    }
 }

--- a/tools/SendTestData.ps1
+++ b/tools/SendTestData.ps1
@@ -5,6 +5,7 @@ param(
     [string]$SettingsPath = "$env:LOCALAPPDATA\CrowsNestMqtt\settings.json",
     [string]$Broker = "",
     [int]$BrokerPort = 0,
+    [Nullable[bool]]$UseTls = $null,
     [string]$ImagePath = "",
     [string]$VideoPath = "",
     [string]$JsonPath = "",
@@ -36,11 +37,34 @@ if (-not (Test-Path $dllPath)) {
 }
 Add-Type -Path $dllPath
 
-# Read settings
-$settings = Get-Content $SettingsPath | ConvertFrom-Json
-$mqttHost = if ($Broker) { $Broker } elseif ($settings.Hostname) { $settings.Hostname } else { "localhost" }
-$port = if ($BrokerPort -gt 0) { $BrokerPort } elseif ($settings.Port -and $settings.Port -gt 0) { $settings.Port } else { 1883 }
-$useTls = $settings.UseTls
+# Read settings (optional — file may not exist when running from Aspire/CI)
+$settings = $null
+if (Test-Path -LiteralPath $SettingsPath) {
+    try {
+        $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+    } catch {
+        Write-Warning "Failed to parse settings file '$SettingsPath': $($_.Exception.Message). Continuing without it."
+    }
+}
+
+$mqttHost = if ($Broker) { $Broker } elseif ($settings -and $settings.Hostname) { $settings.Hostname } else { "localhost" }
+$port = if ($BrokerPort -gt 0) { $BrokerPort } elseif ($settings -and $settings.Port -and $settings.Port -gt 0) { $settings.Port } else { 1883 }
+
+# Resolve TLS in this order:
+#   1) explicit -UseTls parameter
+#   2) MQTT_USE_TLS environment variable (set by Aspire AppHost, e.g. "false")
+#   3) settings.UseTls from settings.json
+#   4) default $false (Aspire's EMQX plain-TCP listener doesn't speak TLS)
+if ($null -ne $UseTls) {
+    $useTls = [bool]$UseTls
+} elseif ($env:MQTT_USE_TLS) {
+    $useTls = [System.Convert]::ToBoolean($env:MQTT_USE_TLS)
+} elseif ($settings -and $null -ne $settings.UseTls) {
+    $useTls = [bool]$settings.UseTls
+} else {
+    $useTls = $false
+}
+
 $clientId = "pwsh-mqtt-$(Get-Random)"
 $publishTimeout = [TimeSpan]::FromSeconds(30)
 
@@ -81,7 +105,7 @@ function Send-MqttMessage {
 }
 
 # Connect
-Write-Host "Connecting to $mqttHost : $port with client id $clientId"
+Write-Host "Connecting to $mqttHost : $port with client id $clientId (TLS: $useTls)"
 $null = $client.ConnectAsync($options).WaitAsync($publishTimeout).GetAwaiter().GetResult()
 
 # Read image as bytes

--- a/tools/SendTestData.ps1
+++ b/tools/SendTestData.ps1
@@ -29,10 +29,11 @@ if (-not (Test-Path $nuget)) {
     Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/MQTTnet/5.1.0.1559" -OutFile $nuget
 }
 $extractPath = Join-Path $env:TEMP "MQTTnet_extracted_5.1.0"
-if (-not (Test-Path $extractPath)) {
+$dllPath = Join-Path $extractPath "lib\net8.0\MQTTnet.dll"
+if (-not (Test-Path $dllPath)) {
+    if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
     Expand-Archive -Path $nuget -DestinationPath $extractPath -Force
 }
-$dllPath = Join-Path $extractPath "lib\net8.0\MQTTnet.dll"
 Add-Type -Path $dllPath
 
 # Read settings

--- a/tools/SendTestDataDelayed.ps1
+++ b/tools/SendTestDataDelayed.ps1
@@ -1,0 +1,36 @@
+# Requires -Version 7
+# Delayed wrapper for SendTestData.ps1 — used by Aspire AppHost to send test data
+# after the broker has had time to fully initialize and clients have connected.
+
+param(
+    [int]$DelaySeconds = 30
+)
+
+$scriptDir = $PSScriptRoot
+
+# Read broker connection info from environment variables (set by Aspire)
+$broker = $env:MQTT_HOST
+$port = $env:MQTT_PORT
+
+# Fallback: try Aspire service reference format
+if (-not $broker) {
+    $aspireEndpoint = $env:services__mqtt__mqtt__0
+    if ($aspireEndpoint) {
+        $uri = [System.Uri]::new($aspireEndpoint)
+        $broker = $uri.Host
+        $port = $uri.Port
+    }
+}
+
+if (-not $broker -or -not $port) {
+    Write-Error "MQTT_HOST and MQTT_PORT environment variables are not set. Cannot send test data."
+    exit 1
+}
+
+Write-Host "Waiting $DelaySeconds seconds for broker and clients to be ready..."
+Start-Sleep -Seconds $DelaySeconds
+
+Write-Host "Sending test data to $broker`:$port ..."
+& "$scriptDir\SendTestData.ps1" -Broker $broker -BrokerPort ([int]$port)
+
+Write-Host "Test data sent successfully."

--- a/tools/SendTestDataDelayed.ps1
+++ b/tools/SendTestDataDelayed.ps1
@@ -27,10 +27,20 @@ if (-not $broker -or -not $port) {
     exit 1
 }
 
+# Resolve TLS for the Aspire-injected endpoint:
+#   * Honor MQTT_USE_TLS if the AppHost set it (e.g. "false" for plain TCP, "true" for the TLS listener).
+#   * Otherwise default to plain TCP — Aspire's default `mqtt` endpoint points at EMQX's :1883 listener,
+#     and attempting TLS against it produces "Received an unexpected EOF or 0 bytes from the transport stream".
+if ($env:MQTT_USE_TLS) {
+    $useTls = [System.Convert]::ToBoolean($env:MQTT_USE_TLS)
+} else {
+    $useTls = $false
+}
+
 Write-Host "Waiting $DelaySeconds seconds for broker and clients to be ready..."
 Start-Sleep -Seconds $DelaySeconds
 
-Write-Host "Sending test data to $broker`:$port ..."
-& "$scriptDir\SendTestData.ps1" -Broker $broker -BrokerPort ([int]$port)
+Write-Host "Sending test data to $broker`:$port (TLS: $useTls) ..."
+& "$scriptDir\SendTestData.ps1" -Broker $broker -BrokerPort ([int]$port) -UseTls $useTls
 
 Write-Host "Test data sent successfully."


### PR DESCRIPTION
This pull request adds support for connecting to MQTT brokers over WebSocket (both `ws://` and `wss://`) in addition to the existing TCP/TLS support. It introduces the `TransportProtocol` enum throughout the configuration, environment variable handling, and connection logic, and updates both documentation and the Aspire host setup to reflect these new capabilities.

**WebSocket Transport Support:**

* Added a `TransportProtocol` enum (`Tcp`, `WebSocket`) to the codebase and integrated it into environment/configuration handling, including new fields in `SettingsData`, `EnvironmentSettingsOverrides`, and `MqttConnectionSettings`. (`[[1]](diffhunk://#diff-b76afee71c43b2687f4ef2cfcf54a9c551a3c21ed228d5ef705ebebac9f61bcdR1-R17)`, `[[2]](diffhunk://#diff-616ef5bee5a3bf49d0f41380e1ecee99d51d74e04b0e10c55d8e67db2ac0fc9eL20-R22)`, `[[3]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R35-R36)`, `[[4]](diffhunk://#diff-9a6437cc9bcfb8c7f168d58e73d3146581b2e263d626f9e5d252e011f706ebcfR28-R36)`)
* The MQTT connection logic (`MqttEngine.cs`) now builds a WebSocket connection URI and uses it when the transport is set to WebSocket, supporting both secure and insecure WebSocket connections. (`[src/BusinessLogic/MqttEngine.csL182-R200](diffhunk://#diff-32425592c9adb8199ac5b6f8a1395e59bf8f5bc6998195bf7e5eb95d07832096L182-R200)`)

**Configuration and Environment Variable Enhancements:**

* Added support for new environment variables: `CROWSNEST__TRANSPORT` (to select transport protocol) and `CROWSNEST__WEBSOCKET_PATH` (for specifying the WebSocket path). These are parsed and prioritized correctly with Aspire and explicit overrides. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R295-R296)`, `[[2]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R35-R36)`, `[[3]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R93-R114)`)
* Updated Aspire environment variable parsing to handle multiple endpoint schemes (e.g., `mqtt://`, `ws://`, `wss://`), extracting transport protocol, TLS usage, and WebSocket path from the URI. (`[[1]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R57-R73)`, `[[2]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R139-R179)`)

**Aspire Host and Example Updates:**

* The Aspire host (`AppHost/Program.cs`) now launches three `CrowsNestMqtt` instances: one for TCP, one for WebSocket, and one for TLS, setting the appropriate environment variables for each. Also, the EMQX broker is configured to expose WebSocket and TLS endpoints. (`[[1]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666R1-R24)`, `[[2]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666R33-R69)`)
* Added documentation and example environment variable setups for WebSocket connections, both in the README and Aspire usage sections. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L245-R250)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317-R336)`)

**Command and Documentation Improvements:**

* Updated the `:connect` command and documentation to clarify support for WebSocket URIs, including usage examples. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L174-R175)`)

**UI/Settings Integration:**

* Passed the selected transport protocol and WebSocket path from the UI settings into the MQTT connection settings, ensuring the user's choice is respected. (`[src/UI/ViewModels/MainViewModel.csL1051-R1053](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL1051-R1053)`)

These changes collectively enable seamless use of WebSocket transport for MQTT, improve configuration flexibility, and ensure the documentation and Aspire integration are up to date.- Support WebSocket connections in config, UI, and :connect command
- Add CROWSNEST__TRANSPORT and CROWSNEST__WEBSOCKET_PATH env vars
- Parse Aspire endpoint URIs for protocol, TLS, and path
- Update MqttEngine to build correct options for TCP/WebSocket
- Extend settings and models with TransportProtocol enum
- Update settings UI for protocol selection and WS path
- Add unit tests for WebSocket and env var handling
- Update Aspire Program.cs for multi-transport client launch
- Improve test data sender scripts for WebSocket endpoints