### PR TITLE
Add SQLite auto-log for MQTT topics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,5 +39,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Set per-topic message buffer limits to manage memory usage:
 - **Topic Filter**: MQTT topic or wildcard (e.g., `#` for all topics).
 - **Max Size (Bytes)**: Maximum buffer size for each topic.
 
+**5. SQLite Auto-Log**
+Automatically persist selected MQTT topics to a local SQLite database for external time-series querying:
+- **Auto-Log Rules**: MQTT topic filters using the same matching logic as topic buffer limits, including exact topics, `+`, and `#`.
+- **Max DB Size (Bytes)**: Maximum SQLite database size. Defaults to `104857600` (100 MB). When the database exceeds the limit, the oldest logged rows are discarded globally.
+- **Database Location**: The database is created inside the configured export path as `crowsnest-auto-log.sqlite`.
+- Tables are created lazily when the first matching message arrives.
+- Logging happens independently from UI pause/filter state and includes retained messages delivered by the broker.
+
 ### Viewers
 Crow's NestMQTT automatically render content of MQTT message as image when the content-type indicates an image
 ![](./doc/images/image-viewer.png)
@@ -195,7 +203,38 @@ Crow's Nest MQTT provides a command interface (likely accessible via a dedicated
 *   `:setauthdata <data>` - Set the authentication data for enhanced authentication (method-specific data).
 *   `:setusetls <true|false>` - Set whether to use TLS for the MQTT connection. When set to `true`, the client will connect using TLS, allow untrusted certificates, and ignore certificate errors.
 *   `:publish [topic] [@file|text]` - Open the publish window. Optionally pre-fill the topic (defaults to the selected topic) and payload from a file (`@path/to/file`) or inline text. The publish window is non-modal and supports all MQTT V5 properties.
+*   `:auto-log [topic-filter]` - Toggle SQLite auto-logging for the selected topic, or for the specified topic/filter. Uses the same filter semantics as topic buffer limits.
 *   `[search_term]` - Any text entered without a `:` prefix is treated as a search term to filter messages.
+
+## SQLite Auto-Log Schema
+
+Auto-log creates one table per concrete topic. Table names are stable and query-friendly:
+
+```text
+mqtt_<sanitized_topic>_<hash8>
+```
+
+For example, `factory/line1/temperature` becomes a table similar to `mqtt_factory_line1_temperature_a13f9c2b`.
+
+The exact topic-to-table mapping is stored in `_auto_log_topics`:
+
+```sql
+select topic, table_name, source_filter, created_at_utc, last_seen_at_utc
+from _auto_log_topics;
+```
+
+Each topic table stores time-series rows with receive time, MQTT metadata, user properties, payload size, and one payload representation based on content type: `payload_json`, `payload_text`, `payload_xml`, `payload_base64`, or `payload_blob`.
+
+For JSON payloads, Crow's NestMQTT adds generated/indexed columns for top-level scalar JSON fields. Example query:
+
+```sql
+select received_at_utc, json_temperature, json_unit
+from mqtt_factory_line1_temperature_a13f9c2b
+where json_temperature > 30
+order by received_at_utc desc;
+```
+
+The `_auto_log_entries` table tracks row age across all topic tables so the oldest logged rows can be discarded when the configured max database size is exceeded.
 
 ## Keyboard Navigation Shortcuts
 
@@ -257,6 +296,14 @@ When an Aspire endpoint environment variable is detected, the application:
       .AddExecutable("mqtt-client", Path.Combine(mqttViewerWorkingDirectory, "CrowsNestMqtt.App.exe"), mqttViewerWorkingDirectory)
       .WithReference(mqttBrokerEndpoint)
       .WaitFor(mqttBroker);
+
+  builder
+      .AddExecutable("mqtt-auto-log", Path.Combine(mqttViewerWorkingDirectory, "CrowsNestMqtt.App.exe"), mqttViewerWorkingDirectory)
+      .WithReference(mqttBrokerEndpoint)
+      .WithEnvironment("CROWSNEST__EXPORT_PATH", Path.Combine(mqttViewerWorkingDirectory, "exports"))
+      .WithEnvironment("CROWSNEST__AUTO_LOG_TOPIC_RULES", "[{\"TopicFilter\":\"sensors/#\",\"IsEnabled\":true}]")
+      .WithEnvironment("CROWSNEST__AUTO_LOG_MAX_DB_SIZE_BYTES", "104857600")
+      .WaitFor(mqttBroker);
 ```
 
 ## Environment Variable Configuration
@@ -295,6 +342,8 @@ This is useful for:
 | `CROWSNEST__TIMEOUT_SECONDS` | Operation timeout in seconds | int | `5` |
 | `CROWSNEST__DEFAULT_BUFFER_SIZE_BYTES` | Default per-topic buffer size | long | `1048576` |
 | `CROWSNEST__TOPIC_BUFFER_LIMITS` | Per-topic buffer limits (JSON array) | JSON | `[{"TopicFilter":"#","MaxSizeBytes":2097152}]` |
+| `CROWSNEST__AUTO_LOG_TOPIC_RULES` | SQLite auto-log topic rules (JSON array) | JSON | `[{"TopicFilter":"sensors/#","IsEnabled":true}]` |
+| `CROWSNEST__AUTO_LOG_MAX_DB_SIZE_BYTES` | Max SQLite auto-log DB size before oldest rows are discarded | long | `104857600` |
 
 ### Priority
 
@@ -321,6 +370,9 @@ export CROWSNEST__AUTH_USERNAME=svc-account
 export CROWSNEST__AUTH_PASSWORD=secret
 export CROWSNEST__CLIENT_ID=monitoring-client
 export CROWSNEST__KEEP_ALIVE_SECONDS=60
+export CROWSNEST__EXPORT_PATH=/tmp/crowsnest-exports
+export CROWSNEST__AUTO_LOG_TOPIC_RULES='[{"TopicFilter":"sensors/#","IsEnabled":true}]'
+export CROWSNEST__AUTO_LOG_MAX_DB_SIZE_BYTES=104857600
 ```
 
 ## Scripts

--- a/src/BusinessLogic/BusinessLogic.csproj
+++ b/src/BusinessLogic/BusinessLogic.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BusinessLogic/Commands/CommandType.cs
+++ b/src/BusinessLogic/Commands/CommandType.cs
@@ -61,6 +61,8 @@ public enum CommandType
     GotoResponse,
     /// <summary> Publish a message to a topic. </summary>
     Publish,
+    /// <summary> Toggle automatic SQLite logging for a topic or topic filter. </summary>
+    AutoLog,
     /// <summary> Represents an unrecognized or invalid command. </summary>
     Unknown
 }

--- a/src/BusinessLogic/Configutation/AutoLogTopicRule.cs
+++ b/src/BusinessLogic/Configutation/AutoLogTopicRule.cs
@@ -1,0 +1,6 @@
+namespace CrowsNestMqtt.BusinessLogic.Configuration;
+
+/// <summary>
+/// Defines a topic filter that should be automatically logged to SQLite.
+/// </summary>
+public record AutoLogTopicRule(string TopicFilter, bool IsEnabled = true);

--- a/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
+++ b/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
@@ -33,6 +33,8 @@ public sealed record EnvironmentSettingsOverrides
     public int? TimeoutPeriodSeconds { get; init; }
     public long? DefaultTopicBufferSizeBytes { get; init; }
     public IList<TopicBufferLimit>? TopicSpecificBufferLimits { get; init; }
+    public IList<AutoLogTopicRule>? AutoLogTopicRules { get; init; }
+    public long? AutoLogMaxDatabaseSizeBytes { get; init; }
 
     /// <summary>
     /// Whether any environment variable overrides were detected.
@@ -82,6 +84,8 @@ public sealed record EnvironmentSettingsOverrides
         var timeoutSeconds = ReadInt("TIMEOUT_SECONDS");
         var defaultBufferSize = ReadLong("DEFAULT_BUFFER_SIZE_BYTES");
         var topicLimits = ReadTopicBufferLimits("TOPIC_BUFFER_LIMITS");
+        var autoLogRules = ReadAutoLogTopicRules("AUTO_LOG_TOPIC_RULES");
+        var autoLogMaxDbSize = ReadLong("AUTO_LOG_MAX_DB_SIZE_BYTES");
         var authMode = ReadAuthMode();
 
         // Explicit CROWSNEST__ hostname/port override Aspire-derived values
@@ -96,7 +100,8 @@ public sealed record EnvironmentSettingsOverrides
             || exportFormat.HasValue || exportPath != null
             || maxTopicLimit.HasValue || parallelismDegree.HasValue
             || timeoutSeconds.HasValue || defaultBufferSize.HasValue
-            || topicLimits != null || authMode != null;
+            || topicLimits != null || autoLogRules != null || autoLogMaxDbSize.HasValue
+            || authMode != null;
 
         if (hasAny)
         {
@@ -121,6 +126,8 @@ public sealed record EnvironmentSettingsOverrides
             TimeoutPeriodSeconds = timeoutSeconds,
             DefaultTopicBufferSizeBytes = defaultBufferSize,
             TopicSpecificBufferLimits = topicLimits,
+            AutoLogTopicRules = autoLogRules,
+            AutoLogMaxDatabaseSizeBytes = autoLogMaxDbSize,
             HasOverrides = hasAny,
             IsAspireEnvironment = isAspire
         };
@@ -224,6 +231,22 @@ public sealed record EnvironmentSettingsOverrides
         {
             var limits = JsonSerializer.Deserialize<List<TopicBufferLimit>>(value);
             return limits;
+        }
+        catch (JsonException ex)
+        {
+            AppLogger.Error(ex, "Failed to parse {EnvVar} environment variable as JSON", Prefix + name);
+            return null;
+        }
+    }
+
+    private static IList<AutoLogTopicRule>? ReadAutoLogTopicRules(string name)
+    {
+        var value = ReadString(name);
+        if (value == null) return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<AutoLogTopicRule>>(value);
         }
         catch (JsonException ex)
         {

--- a/src/BusinessLogic/Configutation/SettingsData.cs
+++ b/src/BusinessLogic/Configutation/SettingsData.cs
@@ -17,9 +17,11 @@ public record SettingsData(
     int MaxTopicLimit = 500,
     int ParallelismDegree = 4,
     int TimeoutPeriodSeconds = 5,
-    int SubscriptionQoS = 1)
+    int SubscriptionQoS = 1,
+    long AutoLogMaxDatabaseSizeBytes = 100 * 1024 * 1024)
 {
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; init; } = new List<TopicBufferLimit>();
+    public IList<AutoLogTopicRule> AutoLogTopicRules { get; init; } = new List<AutoLogTopicRule>();
     /// <summary>
     /// Default buffer size in bytes for topics that don't match any specific rules.
     /// If null, uses the system default (1 MB). This only applies when no "#" wildcard rule is configured.

--- a/src/BusinessLogic/Services/AutoLogService.cs
+++ b/src/BusinessLogic/Services/AutoLogService.cs
@@ -1,0 +1,564 @@
+namespace CrowsNestMqtt.BusinessLogic.Services;
+
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+using Microsoft.Data.Sqlite;
+using MQTTnet;
+using MQTTnet.Packets;
+using Serilog;
+
+public sealed class AutoLogService : IAutoLogService
+{
+    private const long DefaultMaxDatabaseSizeBytes = 100 * 1024 * 1024;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly Dictionary<string, HashSet<string>> _knownJsonColumnsByTable = new(StringComparer.OrdinalIgnoreCase);
+    private List<AutoLogTopicRule> _rules = new();
+    private string _databasePath = GetDefaultDatabasePath(null);
+    private long _maxDatabaseSizeBytes = DefaultMaxDatabaseSizeBytes;
+    private bool _disposed;
+
+    public void UpdateConfiguration(string? exportPath, IEnumerable<AutoLogTopicRule> rules, long maxDatabaseSizeBytes)
+    {
+        _databasePath = GetDefaultDatabasePath(exportPath);
+        _rules = rules
+            .Where(r => !string.IsNullOrWhiteSpace(r.TopicFilter))
+            .Select(r => new AutoLogTopicRule(NormalizeTopicFilter(r.TopicFilter), r.IsEnabled))
+            .ToList();
+        _maxDatabaseSizeBytes = maxDatabaseSizeBytes > 0 ? maxDatabaseSizeBytes : DefaultMaxDatabaseSizeBytes;
+    }
+
+    public bool IsEnabledForTopic(string topic)
+    {
+        return ResolveRule(topic) is { IsEnabled: true };
+    }
+
+    public async Task LogBatchAsync(IReadOnlyList<IdentifiedMqttApplicationMessageReceivedEventArgs> batch, CancellationToken cancellationToken = default)
+    {
+        if (_disposed || batch.Count == 0 || _rules.Count == 0)
+        {
+            return;
+        }
+
+        var matched = batch
+            .Select(item => (Item: item, Rule: ResolveRule(item.Topic)))
+            .Where(item => item.Rule is { IsEnabled: true })
+            .ToList();
+
+        if (matched.Count == 0)
+        {
+            return;
+        }
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_databasePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = _databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Cache = SqliteCacheMode.Shared
+            }.ToString());
+
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await ExecuteNonQueryAsync(connection, "PRAGMA journal_mode=WAL;", cancellationToken).ConfigureAwait(false);
+            await ExecuteNonQueryAsync(connection, "PRAGMA busy_timeout=5000;", cancellationToken).ConfigureAwait(false);
+            await EnsureGlobalTablesAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var (item, rule) in matched)
+            {
+                if (rule == null)
+                {
+                    continue;
+                }
+
+                await LogMessageAsync(connection, transaction, item, rule.TopicFilter, cancellationToken).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await PruneIfNeededAsync(connection, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to auto-log MQTT batch to SQLite at {Path}", _databasePath);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _writeLock.Dispose();
+    }
+
+    public static string GetTableNameForTopic(string topic)
+    {
+        var normalized = NormalizeTopicFilter(topic);
+        var sanitized = Regex.Replace(normalized, "[^A-Za-z0-9_]+", "_").Trim('_').ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "root";
+        }
+
+        if (sanitized.Length > 72)
+        {
+            sanitized = sanitized[..72].Trim('_');
+        }
+
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..8].ToLowerInvariant();
+        return $"mqtt_{sanitized}_{hash}";
+    }
+
+    private async Task LogMessageAsync(SqliteConnection connection, System.Data.Common.DbTransaction transaction, IdentifiedMqttApplicationMessageReceivedEventArgs item, string sourceFilter, CancellationToken cancellationToken)
+    {
+        var message = item.ApplicationMessage;
+        var topic = item.Topic;
+        var tableName = GetTableNameForTopic(topic);
+        await EnsureTopicTableAsync(connection, transaction, tableName, topic, sourceFilter, cancellationToken).ConfigureAwait(false);
+
+        var payload = message.Payload.ToArray();
+        var payloadInfo = BuildPayloadInfo(message, payload);
+        if (payloadInfo.JsonFields.Count > 0)
+        {
+            await EnsureJsonColumnsAsync(connection, transaction, tableName, payloadInfo.JsonFields, cancellationToken).ConfigureAwait(false);
+        }
+
+        var metadataJson = JsonSerializer.Serialize(BuildMetadata(item));
+        var userPropertiesJson = JsonSerializer.Serialize(message.UserProperties?.ToDictionary(p => p.Name, p => p.ReadValueAsString()) ?? new Dictionary<string, string>());
+        var receivedAtUtc = DateTime.UtcNow.ToString("O");
+
+        var sql = $"""
+            INSERT INTO {QuoteIdentifier(tableName)} (
+                received_at_utc, message_id, topic, is_retained, is_own_message,
+                qos, retain, payload_format_indicator, content_type, response_topic,
+                correlation_data_hex, message_expiry_interval, metadata_json, user_properties_json,
+                payload_size, payload_json, payload_text, payload_xml, payload_base64, payload_blob)
+            VALUES (
+                $received_at_utc, $message_id, $topic, $is_retained, $is_own_message,
+                $qos, $retain, $payload_format_indicator, $content_type, $response_topic,
+                $correlation_data_hex, $message_expiry_interval, $metadata_json, $user_properties_json,
+                $payload_size, $payload_json, $payload_text, $payload_xml, $payload_base64, $payload_blob)
+            RETURNING id;
+            """;
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$received_at_utc", receivedAtUtc);
+        command.Parameters.AddWithValue("$message_id", item.MessageId.ToString());
+        command.Parameters.AddWithValue("$topic", topic);
+        command.Parameters.AddWithValue("$is_retained", item.IsEffectivelyRetained ? 1 : 0);
+        command.Parameters.AddWithValue("$is_own_message", item.IsOwnMessage ? 1 : 0);
+        command.Parameters.AddWithValue("$qos", (int)message.QualityOfServiceLevel);
+        command.Parameters.AddWithValue("$retain", message.Retain ? 1 : 0);
+        command.Parameters.AddWithValue("$payload_format_indicator", (int)message.PayloadFormatIndicator);
+        command.Parameters.AddWithValue("$content_type", (object?)message.ContentType ?? DBNull.Value);
+        command.Parameters.AddWithValue("$response_topic", (object?)message.ResponseTopic ?? DBNull.Value);
+        command.Parameters.AddWithValue("$correlation_data_hex", message.CorrelationData == null ? DBNull.Value : Convert.ToHexString(message.CorrelationData));
+        command.Parameters.AddWithValue("$message_expiry_interval", (long)message.MessageExpiryInterval);
+        command.Parameters.AddWithValue("$metadata_json", metadataJson);
+        command.Parameters.AddWithValue("$user_properties_json", userPropertiesJson);
+        command.Parameters.AddWithValue("$payload_size", payload.Length);
+        command.Parameters.AddWithValue("$payload_json", (object?)payloadInfo.Json ?? DBNull.Value);
+        command.Parameters.AddWithValue("$payload_text", (object?)payloadInfo.Text ?? DBNull.Value);
+        command.Parameters.AddWithValue("$payload_xml", (object?)payloadInfo.Xml ?? DBNull.Value);
+        command.Parameters.AddWithValue("$payload_base64", (object?)payloadInfo.Base64 ?? DBNull.Value);
+        command.Parameters.Add("$payload_blob", SqliteType.Blob).Value = (object?)payloadInfo.Blob ?? DBNull.Value;
+
+        var rowId = (long)(await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) ?? 0L);
+
+        await using var indexCommand = connection.CreateCommand();
+        indexCommand.Transaction = (SqliteTransaction)transaction;
+        indexCommand.CommandText = """
+            INSERT INTO _auto_log_entries (table_name, row_id, received_at_utc, payload_size)
+            VALUES ($table_name, $row_id, $received_at_utc, $payload_size);
+            """;
+        indexCommand.Parameters.AddWithValue("$table_name", tableName);
+        indexCommand.Parameters.AddWithValue("$row_id", rowId);
+        indexCommand.Parameters.AddWithValue("$received_at_utc", receivedAtUtc);
+        indexCommand.Parameters.AddWithValue("$payload_size", payload.Length);
+        await indexCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureGlobalTablesAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await ExecuteNonQueryAsync(connection, """
+            CREATE TABLE IF NOT EXISTS _auto_log_topics (
+                topic TEXT PRIMARY KEY,
+                table_name TEXT NOT NULL UNIQUE,
+                source_filter TEXT NOT NULL,
+                created_at_utc TEXT NOT NULL,
+                last_seen_at_utc TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS _auto_log_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                table_name TEXT NOT NULL,
+                row_id INTEGER NOT NULL,
+                received_at_utc TEXT NOT NULL,
+                payload_size INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_auto_log_entries_received_at ON _auto_log_entries(received_at_utc, id);
+            """, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureTopicTableAsync(SqliteConnection connection, System.Data.Common.DbTransaction transaction, string tableName, string topic, string sourceFilter, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = $"""
+            CREATE TABLE IF NOT EXISTS {QuoteIdentifier(tableName)} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                received_at_utc TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                topic TEXT NOT NULL,
+                is_retained INTEGER NOT NULL,
+                is_own_message INTEGER NOT NULL,
+                qos INTEGER NOT NULL,
+                retain INTEGER NOT NULL,
+                payload_format_indicator INTEGER NOT NULL,
+                content_type TEXT NULL,
+                response_topic TEXT NULL,
+                correlation_data_hex TEXT NULL,
+                message_expiry_interval INTEGER NOT NULL,
+                metadata_json TEXT NOT NULL,
+                user_properties_json TEXT NOT NULL,
+                payload_size INTEGER NOT NULL,
+                payload_json TEXT NULL,
+                payload_text TEXT NULL,
+                payload_xml TEXT NULL,
+                payload_base64 TEXT NULL,
+                payload_blob BLOB NULL
+            );
+            CREATE INDEX IF NOT EXISTS {QuoteIdentifier($"idx_{tableName}_received_at")} ON {QuoteIdentifier(tableName)}(received_at_utc);
+            INSERT INTO _auto_log_topics (topic, table_name, source_filter, created_at_utc, last_seen_at_utc)
+            VALUES ($topic, $table_name, $source_filter, $now, $now)
+            ON CONFLICT(topic) DO UPDATE SET
+                source_filter = excluded.source_filter,
+                last_seen_at_utc = excluded.last_seen_at_utc;
+            """;
+        command.Parameters.AddWithValue("$topic", topic);
+        command.Parameters.AddWithValue("$table_name", tableName);
+        command.Parameters.AddWithValue("$source_filter", sourceFilter);
+        command.Parameters.AddWithValue("$now", DateTime.UtcNow.ToString("O"));
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureJsonColumnsAsync(SqliteConnection connection, System.Data.Common.DbTransaction transaction, string tableName, IReadOnlyCollection<string> fields, CancellationToken cancellationToken)
+    {
+        if (!_knownJsonColumnsByTable.TryGetValue(tableName, out var known))
+        {
+            known = await LoadColumnNamesAsync(connection, transaction, tableName, cancellationToken).ConfigureAwait(false);
+            _knownJsonColumnsByTable[tableName] = known;
+        }
+
+        foreach (var field in fields)
+        {
+            var column = "json_" + SanitizeColumnName(field);
+            if (!known.Add(column))
+            {
+                continue;
+            }
+
+            var jsonPath = BuildJsonPath(field);
+            await ExecuteNonQueryAsync(connection, transaction, $"ALTER TABLE {QuoteIdentifier(tableName)} ADD COLUMN {QuoteIdentifier(column)} TEXT GENERATED ALWAYS AS (json_extract(payload_json, {QuoteLiteral(jsonPath)})) VIRTUAL;", cancellationToken).ConfigureAwait(false);
+            await ExecuteNonQueryAsync(connection, transaction, $"CREATE INDEX IF NOT EXISTS {QuoteIdentifier($"idx_{tableName}_{column}")} ON {QuoteIdentifier(tableName)}({QuoteIdentifier(column)});", cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<HashSet<string>> LoadColumnNamesAsync(SqliteConnection connection, System.Data.Common.DbTransaction transaction, string tableName, CancellationToken cancellationToken)
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = $"PRAGMA table_xinfo({QuoteIdentifier(tableName)});";
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            result.Add(reader.GetString(1));
+        }
+
+        return result;
+    }
+
+    private async Task PruneIfNeededAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await ExecuteNonQueryAsync(connection, "PRAGMA wal_checkpoint(TRUNCATE);", cancellationToken).ConfigureAwait(false);
+        if (!File.Exists(_databasePath) || new FileInfo(_databasePath).Length <= _maxDatabaseSizeBytes)
+        {
+            return;
+        }
+
+        while (new FileInfo(_databasePath).Length > _maxDatabaseSizeBytes)
+        {
+            await using var select = connection.CreateCommand();
+            select.CommandText = "SELECT id, table_name, row_id FROM _auto_log_entries ORDER BY received_at_utc, id LIMIT 250;";
+            var rows = new List<(long Id, string TableName, long RowId)>();
+            await using (var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    rows.Add((reader.GetInt64(0), reader.GetString(1), reader.GetInt64(2)));
+                }
+            }
+
+            if (rows.Count == 0)
+            {
+                break;
+            }
+
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var row in rows)
+            {
+                await ExecuteNonQueryAsync(connection, transaction, $"DELETE FROM {QuoteIdentifier(row.TableName)} WHERE id = {row.RowId};", cancellationToken).ConfigureAwait(false);
+                await ExecuteNonQueryAsync(connection, transaction, $"DELETE FROM _auto_log_entries WHERE id = {row.Id};", cancellationToken).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await ExecuteNonQueryAsync(connection, "VACUUM;", cancellationToken).ConfigureAwait(false);
+            await ExecuteNonQueryAsync(connection, "PRAGMA wal_checkpoint(TRUNCATE);", cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private AutoLogTopicRule? ResolveRule(string topic)
+    {
+        AutoLogTopicRule? best = null;
+        var bestScore = -1;
+        foreach (var rule in _rules)
+        {
+            var score = MatchTopic(topic, rule.TopicFilter);
+            if (score > bestScore)
+            {
+                best = rule;
+                bestScore = score;
+            }
+        }
+
+        return bestScore >= 0 ? best : null;
+    }
+
+    public static int MatchTopic(string topic, string filter)
+    {
+        if (string.IsNullOrEmpty(topic) || string.IsNullOrEmpty(filter))
+        {
+            return -1;
+        }
+
+        if (filter == topic)
+        {
+            return 1000;
+        }
+
+        var topicSegments = topic.Split('/');
+        var filterSegments = filter.Split('/');
+        var score = 0;
+        var i = 0;
+        var j = 0;
+
+        while (i < topicSegments.Length && j < filterSegments.Length)
+        {
+            if (filterSegments[j] == "#")
+            {
+                if (j == filterSegments.Length - 1)
+                {
+                    i = topicSegments.Length;
+                    break;
+                }
+
+                return -1;
+            }
+
+            if (filterSegments[j] == topicSegments[i])
+            {
+                score += 10;
+            }
+            else if (filterSegments[j] == "+")
+            {
+                score += 5;
+            }
+            else
+            {
+                return -1;
+            }
+
+            i++;
+            j++;
+        }
+
+        if (i == topicSegments.Length && j == filterSegments.Length)
+        {
+            return score;
+        }
+
+        if (j == filterSegments.Length - 1 && filterSegments[j] == "#" && i == topicSegments.Length)
+        {
+            return score + 1;
+        }
+
+        return -1;
+    }
+
+    private static PayloadInfo BuildPayloadInfo(MqttApplicationMessage message, byte[] payload)
+    {
+        if (payload.Length == 0)
+        {
+            return new PayloadInfo(Text: string.Empty);
+        }
+
+        var contentType = message.ContentType ?? string.Empty;
+        var decoded = TryDecodeUtf8(payload);
+        var looksJson = contentType.Contains("json", StringComparison.OrdinalIgnoreCase);
+        if ((looksJson || decoded != null) && TryParseJson(decoded, out var jsonFields))
+        {
+            return new PayloadInfo(Json: decoded, JsonFields: jsonFields);
+        }
+
+        if (contentType.Contains("xml", StringComparison.OrdinalIgnoreCase))
+        {
+            return decoded != null ? new PayloadInfo(Xml: decoded) : new PayloadInfo(Base64: Convert.ToBase64String(payload));
+        }
+
+        if (contentType.StartsWith("text/", StringComparison.OrdinalIgnoreCase) || decoded != null && message.PayloadFormatIndicator.ToString().Contains("Character", StringComparison.OrdinalIgnoreCase))
+        {
+            return decoded != null ? new PayloadInfo(Text: decoded) : new PayloadInfo(Base64: Convert.ToBase64String(payload));
+        }
+
+        return new PayloadInfo(Blob: payload);
+    }
+
+    private static Dictionary<string, object?> BuildMetadata(IdentifiedMqttApplicationMessageReceivedEventArgs item)
+    {
+        var message = item.ApplicationMessage;
+        return new Dictionary<string, object?>
+        {
+            ["messageId"] = item.MessageId,
+            ["clientId"] = item.ClientId,
+            ["processingFailed"] = item.ProcessingFailed,
+            ["isEffectivelyRetained"] = item.IsEffectivelyRetained,
+            ["isOwnMessage"] = item.IsOwnMessage,
+            ["qos"] = (int)message.QualityOfServiceLevel,
+            ["retain"] = message.Retain,
+            ["payloadFormatIndicator"] = (int)message.PayloadFormatIndicator,
+            ["contentType"] = message.ContentType,
+            ["responseTopic"] = message.ResponseTopic,
+            ["correlationDataHex"] = message.CorrelationData == null ? null : Convert.ToHexString(message.CorrelationData),
+            ["messageExpiryInterval"] = message.MessageExpiryInterval
+        };
+    }
+
+    private static bool TryParseJson(string? value, out IReadOnlyCollection<string> fields)
+    {
+        fields = Array.Empty<string>();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return true;
+            }
+
+            fields = document.RootElement.EnumerateObject()
+                .Where(p => p.Value.ValueKind is JsonValueKind.String or JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null)
+                .Select(p => p.Name)
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Take(64)
+                .ToArray();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string? TryDecodeUtf8(byte[] payload)
+    {
+        try
+        {
+            return new UTF8Encoding(false, true).GetString(payload);
+        }
+        catch (DecoderFallbackException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetDefaultDatabasePath(string? exportPath)
+    {
+        var folder = string.IsNullOrWhiteSpace(exportPath)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CrowsNestMqtt", "exports")
+            : exportPath;
+        return Path.Combine(folder, "crowsnest-auto-log.sqlite");
+    }
+
+    private static string NormalizeTopicFilter(string topicFilter) => topicFilter.Trim().TrimEnd('/');
+
+    private static string SanitizeColumnName(string field)
+    {
+        var sanitized = Regex.Replace(field, "[^A-Za-z0-9_]+", "_").Trim('_').ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "field";
+        }
+
+        if (char.IsDigit(sanitized[0]))
+        {
+            sanitized = "field_" + sanitized;
+        }
+
+        return sanitized.Length > 64 ? sanitized[..64].Trim('_') : sanitized;
+    }
+
+    private static string BuildJsonPath(string field) => Regex.IsMatch(field, "^[A-Za-z_][A-Za-z0-9_]*$")
+        ? "$." + field
+        : "$.\"" + field.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+    private static string QuoteIdentifier(string value) => "\"" + value.Replace("\"", "\"\"") + "\"";
+
+    private static string QuoteLiteral(string value) => "'" + value.Replace("'", "''") + "'";
+
+    private static async Task ExecuteNonQueryAsync(SqliteConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task ExecuteNonQueryAsync(SqliteConnection connection, System.Data.Common.DbTransaction transaction, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed record PayloadInfo(
+        string? Json = null,
+        string? Text = null,
+        string? Xml = null,
+        string? Base64 = null,
+        byte[]? Blob = null,
+        IReadOnlyCollection<string>? JsonFields = null)
+    {
+        public IReadOnlyCollection<string> JsonFields { get; } = JsonFields ?? Array.Empty<string>();
+    }
+}

--- a/src/BusinessLogic/Services/CommandParserService.cs
+++ b/src/BusinessLogic/Services/CommandParserService.cs
@@ -394,6 +394,14 @@ public class CommandParserService : ICommandParserService
                 }
                 return CommandResult.Failure("Invalid arguments for :publish. Expected: :publish [topic] [payload|@filepath]");
 
+            case "auto-log":
+            case "autolog":
+                if (arguments.Count <= 1)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.AutoLog, arguments));
+                }
+                return CommandResult.Failure("Invalid arguments for :auto-log. Expected: :auto-log [topic-filter]");
+
             default:
                 return CommandResult.Failure($"Unknown command: '{commandKeyword}'");
         }

--- a/src/BusinessLogic/Services/IAutoLogService.cs
+++ b/src/BusinessLogic/Services/IAutoLogService.cs
@@ -1,0 +1,12 @@
+namespace CrowsNestMqtt.BusinessLogic.Services;
+
+using CrowsNestMqtt.BusinessLogic.Configuration;
+
+public interface IAutoLogService : IDisposable
+{
+    void UpdateConfiguration(string? exportPath, IEnumerable<AutoLogTopicRule> rules, long maxDatabaseSizeBytes);
+
+    Task LogBatchAsync(IReadOnlyList<IdentifiedMqttApplicationMessageReceivedEventArgs> batch, CancellationToken cancellationToken = default);
+
+    bool IsEnabledForTopic(string topic);
+}

--- a/src/UI/ViewModels/AutoLogTopicRuleViewModel.cs
+++ b/src/UI/ViewModels/AutoLogTopicRuleViewModel.cs
@@ -1,0 +1,32 @@
+namespace CrowsNestMqtt.UI.ViewModels;
+
+using CrowsNestMqtt.BusinessLogic.Configuration;
+using ReactiveUI;
+
+public class AutoLogTopicRuleViewModel : ReactiveObject
+{
+    private string _topicFilter = "new/topic/filter";
+    private bool _isEnabled = true;
+
+    public AutoLogTopicRuleViewModel()
+    {
+    }
+
+    public AutoLogTopicRuleViewModel(AutoLogTopicRule rule)
+    {
+        _topicFilter = rule.TopicFilter;
+        _isEnabled = rule.IsEnabled;
+    }
+
+    public string TopicFilter
+    {
+        get => _topicFilter;
+        set => this.RaiseAndSetIfChanged(ref _topicFilter, value);
+    }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set => this.RaiseAndSetIfChanged(ref _isEnabled, value);
+    }
+}

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -98,6 +98,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     // Publish window support (Feature 007)
     private readonly IPublishHistoryService? _publishHistoryService;
     private readonly IFileAutoCompleteService? _fileAutoCompleteService;
+    private readonly IAutoLogService _autoLogService;
     private PublishViewModel? _publishViewModel;
 
     // Topic normalization helper (single place)
@@ -162,6 +163,8 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
                 Log.Debug("SelectedNode changed. Raw='{Raw}' Normalized='{Norm}'", _selectedNode?.FullPath, _normalizedSelectedPath);
                 this.RaisePropertyChanged(nameof(IsDeleteButtonEnabled));
                 this.RaisePropertyChanged(nameof(IsExportAllButtonEnabled));
+                this.RaisePropertyChanged(nameof(IsAutoLogButtonEnabled));
+                this.RaisePropertyChanged(nameof(IsSelectedTopicAutoLogged));
                 CurrentSearchTerm = string.Empty;
 
                 // Immediate best-effort selection using current filtered snapshot
@@ -715,6 +718,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     public ReactiveCommand<object?, Unit> ExportMessageCommand { get; } // T020: Added command to export single message from row button
     public ReactiveCommand<Unit, Unit> ExportAllCommand { get; } // T021: Added command to export all messages from selected topic
     public ReactiveCommand<Unit, Unit> TogglePublishWindowCommand { get; } // Feature 007: Toggle publish window
+    public ReactiveCommand<Unit, Unit> ToggleAutoLogCommand { get; }
 
     // Interaction for requesting clipboard copy from the View
     public Interaction<string, Unit> CopyTextToClipboardInteraction { get; }
@@ -738,6 +742,17 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     /// </summary>
     public PublishViewModel? PublishViewModel => _publishViewModel;
 
+    public bool IsAutoLogButtonEnabled => SelectedNode != null;
+
+    public bool IsSelectedTopicAutoLogged
+    {
+        get
+        {
+            var topic = NormalizeTopic(SelectedNode?.FullPath);
+            return topic != null && _autoLogService.IsEnabledForTopic(topic);
+        }
+    }
+
     /// <summary>
     /// Gets or sets a value indicating whether the main application window currently has focus.
     /// This is used to conditionally enable the global hotkey.
@@ -753,7 +768,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     /// Sets up placeholder data and starts the UI update timer.
     /// </summary>
     // Constructor now requires ICommandParserService
-    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, EnvironmentSettingsOverrides? environmentOverrides = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null)
+    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, EnvironmentSettingsOverrides? environmentOverrides = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null, IAutoLogService? autoLogService = null)
     {
         _commandParserService = commandParserService ?? throw new ArgumentNullException(nameof(commandParserService)); // Store injected service
         _deleteTopicService = deleteTopicService; // Store injected delete topic service (optional)
@@ -761,6 +776,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
         _iconService = iconService; // Store injected icon service (optional)
         _publishHistoryService = publishHistoryService; // Store injected publish history service (optional)
         _fileAutoCompleteService = fileAutoCompleteService; // Store injected file autocomplete service (optional)
+        _autoLogService = autoLogService ?? new AutoLogService();
         _uiScheduler = uiScheduler 
             ?? (Application.Current == null ? Scheduler.Immediate : RxSchedulers.MainThreadScheduler); // Use Immediate in non-Avalonia (plain unit test) context
         _testMode = Application.Current == null
@@ -770,7 +786,9 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
                     || uiScheduler == Scheduler.Immediate; // If ImmediateScheduler is injected, we're definitely in test mode
         _syncContext = SynchronizationContext.Current; // Capture sync context
         Settings = new SettingsViewModel(environmentOverrides); // Instantiate settings with env overrides
+        Settings.SettingsSaved += OnSettingsSaved;
         _environmentOverrides = environmentOverrides;
+        UpdateAutoLogConfiguration();
         JsonViewer = new JsonViewerViewModel(); // Instantiate JSON viewer VM
         CopyTextToClipboardInteraction = new Interaction<string, Unit>(); // Initialize the interaction
         CopyImageToClipboardInteraction = new Interaction<Bitmap, Unit>(); // Initialize the image interaction
@@ -1087,6 +1105,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
         ExportMessageCommand = ReactiveCommand.CreateFromTask<object?>(ExecuteExportMessageAsync); // T020: Initialize export message command
         ExportAllCommand = ReactiveCommand.Create(ExecuteExportAllCommand); // T021: Initialize export all command
         TogglePublishWindowCommand = ReactiveCommand.Create(TogglePublishWindow); // Feature 007: Initialize toggle publish window command
+        ToggleAutoLogCommand = ReactiveCommand.Create(ToggleAutoLogForSelectedTopic);
 
         // --- Property Change Reactions ---
 
@@ -1295,6 +1314,11 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
         // Guard against calls during disposal
         if (_disposedValue)
             return;
+
+        if (batch != null && batch.Count > 0)
+        {
+            _ = _autoLogService.LogBatchAsync(batch, _cts.Token);
+        }
 
         if (IsPaused || batch == null || batch.Count == 0) return;
         ScheduleOnUi(() => ProcessMessageBatchOnUIThread(batch.ToList()));
@@ -3131,6 +3155,9 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                 case CommandType.Publish:
                     HandlePublishCommand(command);
                     break;
+                case CommandType.AutoLog:
+                    HandleAutoLogCommand(command);
+                    break;
                 default:
                     StatusBarText = $"Error: Unknown command type '{command.Type}'.";
                     Log.Warning("Unknown command type encountered: {CommandType}", command.Type);
@@ -3169,8 +3196,79 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         { "deletetopic", (":deletetopic [topic-pattern] [--confirm]", "Deletes retained messages from a topic and its subtopics by publishing empty retained messages. Uses selected topic if no pattern specified.") },
         { "gotoresponse", (":gotoresponse", "Navigates to the response message for the currently selected MQTT v5 request message.") },
         { "settings", (":settings", "Toggles the visibility of the settings pane.") },
-        { "publish", (":publish [topic] [@file|text]", "Opens the publish window. Optionally pre-fills topic and payload from a file (@path) or inline text.") }
+        { "publish", (":publish [topic] [@file|text]", "Opens the publish window. Optionally pre-fills topic and payload from a file (@path) or inline text.") },
+        { "auto-log", (":auto-log [topic-filter]", "Toggles automatic SQLite logging for the selected topic or specified topic filter.") }
     };
+
+    private void OnSettingsSaved(object? sender, EventArgs e)
+    {
+        UpdateAutoLogConfiguration();
+        this.RaisePropertyChanged(nameof(IsSelectedTopicAutoLogged));
+    }
+
+    private void UpdateAutoLogConfiguration()
+    {
+        var settingsData = Settings.Into();
+        _autoLogService.UpdateConfiguration(
+            Settings.ExportPath,
+            settingsData.AutoLogTopicRules,
+            settingsData.AutoLogMaxDatabaseSizeBytes);
+    }
+
+    private void ToggleAutoLogForSelectedTopic()
+    {
+        var topic = NormalizeTopic(SelectedNode?.FullPath);
+        if (topic == null)
+        {
+            StatusBarText = "Error: No topic selected for :auto-log.";
+            return;
+        }
+
+        ToggleAutoLogRule(topic);
+    }
+
+    private void HandleAutoLogCommand(ParsedCommand command)
+    {
+        var topicFilter = command.Arguments.Count == 0
+            ? NormalizeTopic(SelectedNode?.FullPath)
+            : NormalizeTopic(command.Arguments[0]);
+
+        if (topicFilter == null)
+        {
+            StatusBarText = "Error: :auto-log requires a selected topic or argument <topic-filter>.";
+            return;
+        }
+
+        ToggleAutoLogRule(topicFilter);
+    }
+
+    private void ToggleAutoLogRule(string topicFilter)
+    {
+        var existing = Settings.AutoLogTopicRules.FirstOrDefault(rule =>
+            string.Equals(NormalizeTopic(rule.TopicFilter), topicFilter, StringComparison.OrdinalIgnoreCase));
+
+        bool enabled;
+        if (existing == null)
+        {
+            Settings.AutoLogTopicRules.Add(new AutoLogTopicRuleViewModel
+            {
+                TopicFilter = topicFilter,
+                IsEnabled = true
+            });
+            enabled = true;
+        }
+        else
+        {
+            existing.IsEnabled = !existing.IsEnabled;
+            enabled = existing.IsEnabled;
+        }
+
+        UpdateAutoLogConfiguration();
+        this.RaisePropertyChanged(nameof(IsSelectedTopicAutoLogged));
+        StatusBarText = enabled
+            ? $"Auto-log enabled for '{topicFilter}'."
+            : $"Auto-log disabled for '{topicFilter}'.";
+    }
 
     private void DisplayHelpInformation(string? commandName = null)
     {
@@ -4401,6 +4499,8 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                     _correlationService.CorrelationStatusChanged -= OnCorrelationStatusChanged;
                 }
 
+                Settings.SettingsSaved -= OnSettingsSaved;
+
                 // NOW dispose reactive subscriptions - they won't trigger event handlers anymore
                 _messageHistorySubscription?.Dispose();
                 _selectedMessageSubscription?.Dispose(); // Dispose the selected message subscription
@@ -4453,7 +4553,9 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                 CopyPayloadCommand?.Dispose(); // Dispose the new command
                 DeleteTopicCommand?.Dispose(); // Dispose delete topic command
                 NavigateToResponseCommand?.Dispose(); // Dispose navigate to response command
-                                               // Interactions don't typically need explicit disposal unless they hold heavy resources
+                ToggleAutoLogCommand?.Dispose();
+                _autoLogService.Dispose();
+                                                // Interactions don't typically need explicit disposal unless they hold heavy resources
                 _cts.Dispose(); // Dispose the CancellationTokenSource itself
                 }
 

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -30,6 +30,11 @@ using System.Linq; // For .Select
 [JsonSerializable(typeof(TopicBufferLimit))]
 [JsonSerializable(typeof(IList<TopicBufferLimit>))]
 [JsonSerializable(typeof(List<TopicBufferLimit>))] // For deserialization of SettingsData's property
+[JsonSerializable(typeof(AutoLogTopicRule))]
+[JsonSerializable(typeof(IList<AutoLogTopicRule>))]
+[JsonSerializable(typeof(List<AutoLogTopicRule>))]
+[JsonSerializable(typeof(ObservableCollection<AutoLogTopicRuleViewModel>))]
+[JsonSerializable(typeof(AutoLogTopicRuleViewModel))]
 [JsonSerializable(typeof(CrowsNestMqtt.UI.ViewModels.SettingsViewModel.AuthModeSelection))] // Added for enum
 public partial class SettingsViewModelJsonContext : JsonSerializerContext
 {
@@ -63,11 +68,16 @@ public class SettingsViewModel : ReactiveObject
     public ReadOnlyObservableCollection<ExportTypes> AvailableExportTypes => _availableExportTypes; // Changed type and name
 
     public ObservableCollection<TopicBufferLimitViewModel> TopicSpecificLimits { get; } = new();
+    public ObservableCollection<AutoLogTopicRuleViewModel> AutoLogTopicRules { get; } = new();
     private readonly ReadOnlyObservableCollection<AuthModeSelection> _availableAuthenticationModes;
     public ReadOnlyObservableCollection<AuthModeSelection> AvailableAuthenticationModes => _availableAuthenticationModes;
 
     public ReactiveCommand<Unit, Unit> AddTopicLimitCommand { get; }
     public ReactiveCommand<TopicBufferLimitViewModel, Unit> RemoveTopicLimitCommand { get; }
+    public ReactiveCommand<Unit, Unit> AddAutoLogTopicRuleCommand { get; }
+    public ReactiveCommand<AutoLogTopicRuleViewModel, Unit> RemoveAutoLogTopicRuleCommand { get; }
+
+    public event EventHandler? SettingsSaved;
 
 #pragma warning disable IDE0044 // Add readonly modifier
     private bool _isLoading = false; // Flag to prevent saving during initial load
@@ -119,6 +129,16 @@ public class SettingsViewModel : ReactiveObject
             }
         });
 
+        AddAutoLogTopicRuleCommand = ReactiveCommand.Create(() =>
+        {
+            AutoLogTopicRules.Add(new AutoLogTopicRuleViewModel { TopicFilter = "new/topic/filter", IsEnabled = true });
+        });
+
+        RemoveAutoLogTopicRuleCommand = ReactiveCommand.Create<AutoLogTopicRuleViewModel>(rule =>
+        {
+            AutoLogTopicRules.Remove(rule);
+        });
+
         // Observable for simple property changes
         var simplePropertiesChanged = Observable.CombineLatest(
             this.WhenAnyValue(x => x.Hostname),
@@ -136,12 +156,18 @@ public class SettingsViewModel : ReactiveObject
             this.WhenAnyValue(x => x.AuthenticationData),
             this.WhenAnyValue(x => x.UseTls),
             this.WhenAnyValue(x => x.SubscriptionQoS),
-            (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
+            this.WhenAnyValue(x => x.AutoLogMaxDatabaseSizeBytes),
+            (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
 
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
             h => TopicSpecificLimits.CollectionChanged += h,
             h => TopicSpecificLimits.CollectionChanged -= h)
+            .Select(_ => Unit.Default);
+
+        var autoLogCollectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
+            h => AutoLogTopicRules.CollectionChanged += h,
+            h => AutoLogTopicRules.CollectionChanged -= h)
             .Select(_ => Unit.Default);
 
         // Observable for changes to properties of items within TopicSpecificLimits
@@ -166,12 +192,33 @@ public class SettingsViewModel : ReactiveObject
             })
             .Switch(); // Always use the latest set of merged item observables
 
+        var autoLogItemPropertiesChanged = Observable
+            .FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
+                h => AutoLogTopicRules.CollectionChanged += h,
+                h => AutoLogTopicRules.CollectionChanged -= h)
+            .Select(pattern => pattern.EventArgs)
+            .StartWith((System.Collections.Specialized.NotifyCollectionChangedEventArgs?)null)
+            .Select(_ =>
+            {
+                if (!AutoLogTopicRules.Any())
+                {
+                    return Observable.Empty<Unit>();
+                }
+
+                return AutoLogTopicRules
+                    .Select(item => item.WhenAnyValue(i => i.TopicFilter, i => i.IsEnabled).Select(__ => Unit.Default))
+                    .Merge();
+            })
+            .Switch();
+
 
         // Merge all change signals
         Observable.Merge(
                 simplePropertiesChanged,
                 collectionChanged,
-                itemPropertiesChanged.StartWith(Unit.Default) // StartWith to ensure initial state is considered if items exist
+                autoLogCollectionChanged,
+                itemPropertiesChanged.StartWith(Unit.Default), // StartWith to ensure initial state is considered if items exist
+                autoLogItemPropertiesChanged.StartWith(Unit.Default)
             )
             .Throttle(TimeSpan.FromMilliseconds(500))
             .ObserveOn(RxSchedulers.TaskpoolScheduler)
@@ -301,10 +348,23 @@ public class SettingsViewModel : ReactiveObject
        get => _exportPath;
        set => this.RaiseAndSetIfChanged(ref _exportPath, value);
    }
+
+    private long _autoLogMaxDatabaseSizeBytes = 100 * 1024 * 1024;
+    public long AutoLogMaxDatabaseSizeBytes
+    {
+        get => _autoLogMaxDatabaseSizeBytes;
+        set => this.RaiseAndSetIfChanged(ref _autoLogMaxDatabaseSizeBytes, Math.Max(1, value));
+    }
+
     public SettingsData Into()
     {
         var topicLimits = TopicSpecificLimits
             .Select(vm => new TopicBufferLimit(vm.TopicFilter, vm.MaxSizeBytes))
+            .ToList();
+
+        var autoLogRules = AutoLogTopicRules
+            .Where(vm => !string.IsNullOrWhiteSpace(vm.TopicFilter))
+            .Select(vm => new AutoLogTopicRule(vm.TopicFilter.Trim(), vm.IsEnabled))
             .ToList();
 
         AuthenticationMode authModeSetting;
@@ -337,10 +397,12 @@ public class SettingsViewModel : ReactiveObject
             ExportFormat,
             ExportPath,
             UseTls,
-            SubscriptionQoS: SubscriptionQoS
+            SubscriptionQoS: SubscriptionQoS,
+            AutoLogMaxDatabaseSizeBytes: AutoLogMaxDatabaseSizeBytes
         )
         {
-            TopicSpecificBufferLimits = topicLimits
+            TopicSpecificBufferLimits = topicLimits,
+            AutoLogTopicRules = autoLogRules
         };
     }
 
@@ -356,7 +418,9 @@ public class SettingsViewModel : ReactiveObject
         ExportPath = settingsData.ExportPath;
         UseTls = settingsData.UseTls;
         SubscriptionQoS = settingsData.SubscriptionQoS;
+        AutoLogMaxDatabaseSizeBytes = settingsData.AutoLogMaxDatabaseSizeBytes;
         TopicSpecificLimits.Clear();
+        AutoLogTopicRules.Clear();
         
         // Ensure we always have the default '#' limit
         bool hasDefaultLimit = false;
@@ -376,6 +440,14 @@ public class SettingsViewModel : ReactiveObject
         if (!hasDefaultLimit)
         {
             TopicSpecificLimits.Insert(0, new TopicBufferLimitViewModel(new TopicBufferLimit("#", 1024 * 1024)));
+        }
+
+        if (settingsData.AutoLogTopicRules != null)
+        {
+            foreach (var rule in settingsData.AutoLogTopicRules)
+            {
+                AutoLogTopicRules.Add(new AutoLogTopicRuleViewModel(rule));
+            }
         }
 
         // Handle AuthMode and credentials
@@ -421,6 +493,7 @@ public class SettingsViewModel : ReactiveObject
         if (overrides.SubscriptionQoS.HasValue) SubscriptionQoS = overrides.SubscriptionQoS.Value;
         if (overrides.ExportFormat.HasValue) ExportFormat = overrides.ExportFormat.Value;
         if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
+        if (overrides.AutoLogMaxDatabaseSizeBytes.HasValue) AutoLogMaxDatabaseSizeBytes = overrides.AutoLogMaxDatabaseSizeBytes.Value;
 
         if (overrides.AuthMode != null)
         {
@@ -459,6 +532,15 @@ public class SettingsViewModel : ReactiveObject
             }
             EnsureDefaultTopicLimit();
         }
+
+        if (overrides.AutoLogTopicRules != null)
+        {
+            AutoLogTopicRules.Clear();
+            foreach (var rule in overrides.AutoLogTopicRules)
+            {
+                AutoLogTopicRules.Add(new AutoLogTopicRuleViewModel(rule));
+            }
+        }
     }
 
     // --- Persistence Methods ---
@@ -483,6 +565,7 @@ public class SettingsViewModel : ReactiveObject
             string json = JsonSerializer.Serialize(dataToSave, SettingsViewModelJsonContext.Default.SettingsData);
             File.WriteAllText(_settingsFilePath, json);
             AppLogger.Information("Settings saved to {FilePath}", _settingsFilePath);
+            SettingsSaved?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -115,6 +115,28 @@
                       HorizontalContentAlignment="Center">
                   <PathIcon Data="{StaticResource send_regular}" Width="16" Height="16"/>
               </Button>
+              <Button x:Name="AutoLogButton"
+                      Content="Auto Log"
+                      Command="{Binding ToggleAutoLogCommand}"
+                      ToolTip.Tip="Toggle SQLite auto-log for the selected topic"
+                      IsEnabled="{Binding IsAutoLogButtonEnabled}"
+                      Classes.ActiveAutoLog="{Binding IsSelectedTopicAutoLogged}"
+                      MinHeight="32"
+                      Padding="12,8"
+                      VerticalContentAlignment="Center"
+                      HorizontalContentAlignment="Center">
+                  <Button.Styles>
+                      <Style Selector="Button">
+                          <Setter Property="FontWeight" Value="Normal"/>
+                      </Style>
+                      <Style Selector="Button:disabled">
+                          <Setter Property="Opacity" Value="0.5"/>
+                      </Style>
+                      <Style Selector="Button.ActiveAutoLog">
+                          <Setter Property="FontWeight" Value="Bold"/>
+                      </Style>
+                  </Button.Styles>
+              </Button>
               <TextBlock Text="Status:" VerticalAlignment="Center" Margin="10,0,0,0"/>
               <PathIcon VerticalAlignment="Center" Margin="5,0"
                         ToolTip.Tip="{Binding ConnectionStatus}"
@@ -441,7 +463,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 21 rows (0-20) for Application Settings -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5">
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -585,6 +607,26 @@
                 
                 <!-- Add New Limit Button -->
                 <Button Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+
+                <!-- Auto Log Settings Header -->
+                <TextBlock Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" Text="SQLite Auto-Log" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+
+                <TextBlock Grid.Row="22" Grid.Column="0" Text="Max DB Size (Bytes):"/>
+                <NumericUpDown Grid.Row="22" Grid.Column="1" Value="{Binding Settings.AutoLogMaxDatabaseSizeBytes, Mode=TwoWay, StringFormat=N0}" ParsingNumberStyle="Integer" Minimum="1" MinWidth="140"/>
+
+                <ItemsControl Grid.Row="23" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.AutoLogTopicRules}" Margin="0,0,0,5">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:AutoLogTopicRuleViewModel}">
+                            <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto" Margin="0,2">
+                                <CheckBox Grid.Column="0" IsChecked="{Binding IsEnabled, Mode=TwoWay}" Margin="0,0,5,0"/>
+                                <TextBox Grid.Column="1" Text="{Binding TopicFilter, Mode=TwoWay}" PlaceholderText="Topic Filter (e.g., sensors/#)" Margin="0,0,5,0" MinWidth="150"/>
+                                <Button Grid.Column="2" Content="Remove" Command="{Binding $parent[ItemsControl].DataContext.Settings.RemoveAutoLogTopicRuleCommand}" CommandParameter="{Binding}" Padding="5,2"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Button Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" Content="Add Auto-Log Rule" Command="{Binding Settings.AddAutoLogTopicRuleCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -180,6 +180,8 @@ namespace CrowsNestMqtt.UnitTests
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", "userpass");
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_USERNAME", "user1");
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_PASSWORD", "pass1");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTO_LOG_TOPIC_RULES", "[{\"TopicFilter\":\"sensors/#\",\"IsEnabled\":true}]");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTO_LOG_MAX_DB_SIZE_BYTES", "2048");
 
                 // Act
                 var result = EnvironmentSettingsOverrides.Load();
@@ -194,6 +196,10 @@ namespace CrowsNestMqtt.UnitTests
                 Assert.Equal(600u, result.SessionExpiryIntervalSeconds);
                 Assert.True(result.UseTls);
                 Assert.Equal(2, result.SubscriptionQoS);
+                Assert.Equal(2048, result.AutoLogMaxDatabaseSizeBytes);
+                Assert.NotNull(result.AutoLogTopicRules);
+                Assert.Single(result.AutoLogTopicRules);
+                Assert.Equal("sensors/#", result.AutoLogTopicRules[0].TopicFilter);
                 Assert.IsType<UsernamePasswordAuthenticationMode>(result.AuthMode);
                 var userPass = (UsernamePasswordAuthenticationMode)result.AuthMode!;
                 Assert.Equal("user1", userPass.Username);
@@ -212,6 +218,8 @@ namespace CrowsNestMqtt.UnitTests
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", null);
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_USERNAME", null);
                 Environment.SetEnvironmentVariable("CROWSNEST__AUTH_PASSWORD", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTO_LOG_TOPIC_RULES", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTO_LOG_MAX_DB_SIZE_BYTES", null);
             }
         }
 

--- a/tests/UnitTests/Services/AutoLogServiceTests.cs
+++ b/tests/UnitTests/Services/AutoLogServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+using CrowsNestMqtt.BusinessLogic.Services;
+using Microsoft.Data.Sqlite;
+using MQTTnet;
+using MQTTnet.Protocol;
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests.Services;
+
+public class AutoLogServiceTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), "crowsnest-autolog-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void GetTableNameForTopic_ReturnsStableReadableName()
+    {
+        var tableName = AutoLogService.GetTableNameForTopic("factory/line1/temperature");
+
+        Assert.StartsWith("mqtt_factory_line1_temperature_", tableName);
+        Assert.Equal(tableName, AutoLogService.GetTableNameForTopic("factory/line1/temperature"));
+    }
+
+    [Theory]
+    [InlineData("sensors/room1/temp", "sensors/#", true)]
+    [InlineData("sensors/room1/temp", "sensors/+/temp", true)]
+    [InlineData("sensors/room1/humidity", "sensors/+/temp", false)]
+    public void MatchTopic_UsesMqttWildcardSemantics(string topic, string filter, bool expected)
+    {
+        Assert.Equal(expected, AutoLogService.MatchTopic(topic, filter) >= 0);
+    }
+
+    [Fact]
+    public async Task LogBatchAsync_JsonPayload_CreatesTopicTableWithGeneratedJsonColumns()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        using var service = new AutoLogService();
+        service.UpdateConfiguration(
+            _tempDirectory,
+            new[] { new AutoLogTopicRule("sensors/#") },
+            100 * 1024 * 1024);
+
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic("sensors/room1/temp")
+            .WithPayload("{\"temperature\":23.5,\"unit\":\"c\"}")
+            .WithContentType("application/json")
+            .WithPayloadFormatIndicator(MqttPayloadFormatIndicator.CharacterData)
+            .WithUserProperty("source", Encoding.UTF8.GetBytes("test"))
+            .Build();
+
+        var args = new IdentifiedMqttApplicationMessageReceivedEventArgs(Guid.NewGuid(), message, "client-1");
+
+        await service.LogBatchAsync(new[] { args });
+
+        var databasePath = Path.Combine(_tempDirectory, "crowsnest-auto-log.sqlite");
+        Assert.True(File.Exists(databasePath));
+
+        await using var connection = new SqliteConnection($"Data Source={databasePath}");
+        await connection.OpenAsync();
+
+        var tableName = AutoLogService.GetTableNameForTopic("sensors/room1/temp");
+        await using (var mapping = connection.CreateCommand())
+        {
+            mapping.CommandText = "SELECT table_name, source_filter FROM _auto_log_topics WHERE topic = 'sensors/room1/temp';";
+            await using var reader = await mapping.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal(tableName, reader.GetString(0));
+            Assert.Equal("sensors/#", reader.GetString(1));
+        }
+
+        await using (var query = connection.CreateCommand())
+        {
+            query.CommandText = $"SELECT json_temperature, json_unit, json_extract(user_properties_json, '$.source') FROM \"{tableName}\";";
+            await using var reader = await query.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("23.5", reader.GetString(0));
+            Assert.Equal("c", reader.GetString(1));
+            Assert.Equal("test", reader.GetString(2));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/tests/UnitTests/Services/CommandParserServiceTests.cs
+++ b/tests/UnitTests/Services/CommandParserServiceTests.cs
@@ -11,6 +11,28 @@ namespace CrowsNestMqtt.UnitTests.Services
         private readonly CommandParserService _parser = new CommandParserService();
         private readonly SettingsData _defaultSettings = new SettingsData("testhost", 1883); // Default settings for parsing
 
+        [Theory]
+        [InlineData(":auto-log")]
+        [InlineData(":auto-log sensors/#")]
+        [InlineData(":autolog sensors/#")]
+        public void ParseCommand_AutoLog_ValidArgs_ShouldSucceed(string input)
+        {
+            var result = CommandParserService.ParseCommand(input, _defaultSettings);
+
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.ParsedCommand);
+            Assert.Equal(CommandType.AutoLog, result.ParsedCommand.Type);
+        }
+
+        [Fact]
+        public void ParseCommand_AutoLog_TooManyArgs_ShouldFail()
+        {
+            var result = CommandParserService.ParseCommand(":auto-log sensors/# extra", _defaultSettings);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Invalid arguments for :auto-log. Expected: :auto-log [topic-filter]", result.ErrorMessage);
+        }
+
         // Tests for :setauthmode
         [Theory]
         [InlineData("anonymous")]


### PR DESCRIPTION
This pull request introduces a new feature for automatic SQLite logging of MQTT topics ("auto-log") and integrates it throughout the application. The changes add support for configuring, enabling, and managing per-topic auto-logging to a local SQLite database, both via environment variables and the UI. Documentation is updated to describe the feature, its configuration, and its schema.

**Key changes include:**

### Auto-Log Feature Implementation

* Added a new `AutoLogTopicRule` record and related configuration properties to support defining topic filters for automatic SQLite logging (`src/BusinessLogic/Configutation/AutoLogTopicRule.cs`, `src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs`, `src/BusinessLogic/Configutation/SettingsData.cs`). [[1]](diffhunk://#diff-c5275c94c20a51b20c30746f165c127c4af7774f249b2c373a7fc9f80e211e1eR1-R6) [[2]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R36-R37) [[3]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R129-R130) [[4]](diffhunk://#diff-616ef5bee5a3bf49d0f41380e1ecee99d51d74e04b0e10c55d8e67db2ac0fc9eL20-R24)
* Introduced the `IAutoLogService` interface for managing auto-log configuration and logging batches of MQTT messages (`src/BusinessLogic/Services/IAutoLogService.cs`).
* Added a new command type (`AutoLog`) to toggle auto-logging for a topic or filter, and updated the command parser to recognize the `:auto-log` command (`src/BusinessLogic/Commands/CommandType.cs`, `src/BusinessLogic/Services/CommandParserService.cs`). [[1]](diffhunk://#diff-9f308a36c9b5c2964f653ec7b79ad362e18a53801aea7d8f915677932b98e01aR64-R65) [[2]](diffhunk://#diff-5c4ed7bafb0985a50f7aa7ccd4fb9bcf4b9612027ee15ebad7501aaa0bdc2ce2R397-R404)

### UI Integration

* Integrated auto-log support into the main view model, including properties and commands for toggling auto-log from the UI, and a new `AutoLogTopicRuleViewModel` for editing rules (`src/UI/ViewModels/MainViewModel.cs`, `src/UI/ViewModels/AutoLogTopicRuleViewModel.cs`). [[1]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR101) [[2]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR166-R167) [[3]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR721) [[4]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defR745-R755) [[5]](diffhunk://#diff-53f5141a4b01f907c038fdae6cbe4183abc5184906e32676f32015f53eca1defL756-R779) [[6]](diffhunk://#diff-adbc38217ab3d6172479400b890aa2bc66d8fa19b4dfc95a2e3e8b7a68541284R1-R32)

### Configuration and Dependency Updates

* Added `Microsoft.Data.Sqlite` as a dependency in both the main and shared package references to enable SQLite operations (`src/BusinessLogic/BusinessLogic.csproj`, `Directory.Packages.props`). [[1]](diffhunk://#diff-1d6c69ad1bc39b239dd8cd8549da7d084cdc4c812a1759695ec36214448a5ce5R13) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R42)
* Extended environment variable support and settings to allow configuration of auto-log topic rules and maximum database size (`src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs`, `README.md`). [[1]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13R87-R88) [[2]](diffhunk://#diff-50ea98e14c1a93ac95543eee8705dd832948193ca9556bc5da9eb540e47a8c13L99-R104) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R345-R346) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R373-R375)

### Documentation

* Updated `README.md` with detailed documentation on the auto-log feature, including its configuration, usage, schema, example queries, and environment variables. Also added example Aspire integration and command documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R132-R139) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206-R238) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R299-R306) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R345-R346) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R373-R375)

These changes collectively add robust, configurable, and user-accessible support for automatic SQLite-based logging of MQTT topics, making it easier to persist and query MQTT data for analytics or external processing.