### PR TITLE
Simplify use of Crows NestMQTT with Azure Event Grid

### DIFF
--- a/CrowsNestMQTT.slnx
+++ b/CrowsNestMQTT.slnx
@@ -7,4 +7,5 @@
   <Project Path="tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj" />
   <Project Path="tests/UnitTests/UnitTests.csproj" />
   <Project Path="tests/AppHost.Tests/AppHost.Tests.csproj" />
+  <Project Path="tests/MockBroker.Tests/MockBroker.Tests.csproj" />
 </Solution>

--- a/CrowsNestMQTT.slnx
+++ b/CrowsNestMQTT.slnx
@@ -4,5 +4,7 @@
   <Project Path="src/UI/UI.csproj" />
   <Project Path="src/Utils/Utils.csproj" />
   <Project Path="src/AppHost/AppHost.csproj" />
+  <Project Path="tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj" />
   <Project Path="tests/UnitTests/UnitTests.csproj" />
+  <Project Path="tests/AppHost.Tests/AppHost.Tests.csproj" />
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <PackageVersion Include="MQTTnet" Version="5.1.0.1559" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="MQTTnet.Server" Version="5.1.0.1559" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Choose the authentication mode:
 - **Enhanced**: For MQTT 5.0 enhanced authentication, specify:
   - **Authentication Method** (e.g., `SCRAM-SHA-1`, `K8S-SAT`)
   - **Authentication Data** (method-specific data)
+- **Azure**: For Azure Event Grid namespace MQTT brokers. Uses
+  `Azure.Identity.DefaultAzureCredential` (env vars → managed identity → Visual
+  Studio → `az login` → interactive browser) to obtain an Entra ID access
+  token. The token is sent via MQTT v5 enhanced authentication using method
+  `OAUTH2-JWT` and is **automatically refreshed before it expires** without
+  reconnecting. Selecting Azure auto-enables TLS, port `8883`, and TCP
+  transport. The default OAuth scope is `https://eventgrid.azure.net/.default`
+  but can be overridden in the **OAuth Scope** field.
 
 **3. Export Options**  
 Control how and where message logs are exported:
@@ -191,9 +199,10 @@ Crow's Nest MQTT provides a command interface (likely accessible via a dedicated
 *   `:settings` - Toggle the visibility of the settings panel.
 *   `:setuser <username>` - Set the username for MQTT authentication.
 *   `:setpass <password>` - Set the password for MQTT authentication.
-*   `:setauthmode <anonymous|userpass|enhanced>` - Set the authentication mode.
+*   `:setauthmode <anonymous|userpass|enhanced|azure>` - Set the authentication mode. Use `azure` to connect to Azure Event Grid namespaces with Entra ID tokens via `DefaultAzureCredential`.
 *   `:setauthmethod <method>` - Set the authentication method for enhanced authentication (e.g., `SCRAM-SHA-1`, `K8S-SAT`).
 *   `:setauthdata <data>` - Set the authentication data for enhanced authentication (method-specific data).
+*   `:setauthscope <scope>` - Set the OAuth scope requested when Azure authentication mode is active. Defaults to `https://eventgrid.azure.net/.default`.
 *   `:setusetls <true|false>` - Set whether to use TLS for the MQTT connection. When set to `true`, the client will connect using TLS, allow untrusted certificates, and ignore certificate errors.
 *   `:publish [topic] [@file|text]` - Open the publish window. Optionally pre-fill the topic (defaults to the selected topic) and payload from a file (`@path/to/file`) or inline text. The publish window is non-modal and supports all MQTT V5 properties.
 *   `[search_term]` - Any text entered without a `:` prefix is treated as a search term to filter messages.
@@ -241,6 +250,71 @@ You can set the authentication mode to `enhanced` using the `:setauthmode` comma
 
 When connecting to a broker with Enhanced Authentication, the client and broker will exchange authentication data until the authentication process is complete.
 
+## Azure Event Grid Namespace (OAUTH2-JWT)
+
+Crow's NestMQTT can connect to **Azure Event Grid namespace** MQTT brokers using Entra ID
+(Microsoft Azure Active Directory) tokens. No certificates or shared keys are required —
+the client uses `Azure.Identity.DefaultAzureCredential` to acquire an access token via
+the standard Azure credential chain (env vars → managed identity → Visual Studio →
+`az login` → interactive browser).
+
+**To connect:**
+
+```
+:setauthmode azure
+:connect mynamespace.eastus-1.ts.eventgrid.azure.net:8883
+```
+
+`:connect` automatically detects Azure Event Grid hostnames (suffix
+`.ts.eventgrid.azure.net`) and switches to Azure auth mode if needed. Selecting Azure
+auth mode also auto-configures TLS, port `8883`, and TCP transport.
+
+**Custom OAuth scope:** the default scope is `https://eventgrid.azure.net/.default`.
+Override with `:setauthscope <scope>` if your tenant requires a different audience.
+
+**Token refresh:** Entra ID tokens expire (typically ~1h). Crow's NestMQTT schedules a
+proactive refresh 5 minutes before expiry and sends a new token via an MQTT v5 `AUTH`
+packet, so long-running sessions stay connected without reconnect.
+
+**Authentication on the client machine:**
+
+| Scenario | Recommended setup |
+|---|---|
+| Local development | `az login` |
+| CI / containers | `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET` env vars (workload identity / service principal) |
+| Azure VM / Container App | Use the host's managed identity (no extra config needed) |
+
+### Local development / Aspire testing (no Azure required)
+
+The repository ships a `MockAzureEventGridBroker` project under `tools/` that emulates
+an Event Grid namespace listener locally: it accepts CONNECT packets whose
+`AuthenticationMethod` is `OAUTH2-JWT` and whose `AuthenticationData` is a
+well-formed JWT (signatures are not verified). The bundled Aspire host launches
+this mock broker alongside a fourth Crow's Nest instance (`crows-nest-mqtt-azure`)
+so you can exercise the full Azure code path with `dotnet run --project src/AppHost`
+without deploying to Azure.
+
+To bypass `DefaultAzureCredential` and use a hand-issued JWT, set the
+`CROWSNEST__AZURE_TOKEN_OVERRIDE` environment variable to the token string. When
+present, `AzureAccessTokenProvider` returns the override directly and the JWT's
+`exp` claim drives the refresh timer (fallback: 1 hour). The Aspire host wires
+this automatically for the fourth instance — you do not need to set it manually
+when running the AppHost.
+
+> ⚠️ **Do not set `CROWSNEST__AZURE_TOKEN_OVERRIDE` in production.** It short-circuits
+> Entra ID entirely and will forward whatever token you provide to the broker.
+
+Automated coverage lives in `tests/AppHost.Tests/AzureAuthModeAspireTests.cs`:
+
+```
+dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release
+```
+
+The tests spawn the mock broker as a child process, connect a real MQTTnet v5
+client with OAUTH2-JWT, and assert that: (1) valid tokens are accepted, (2)
+CONNECTs without an `OAUTH2-JWT` method are rejected, and (3) client-initiated
+MQTT v5 `AUTH` re-authentication packets are received by the broker.
+
 ## dotnet Aspire
 
 Crow's NestMQTT automatically connects to the MQTT Broker endpoint defined via dotnet Aspire environment variables. It supports both `services__mqtt__mqtt__0` and `services__mqtt__default__0` naming conventions. The endpoint URI scheme determines the transport protocol:
@@ -286,11 +360,12 @@ This is useful for:
 | `CROWSNEST__KEEP_ALIVE_SECONDS` | Keep-alive interval in seconds | int | `30` |
 | `CROWSNEST__CLEAN_SESSION` | Whether to use clean session | bool | `true` |
 | `CROWSNEST__SESSION_EXPIRY_SECONDS` | Session expiry interval | uint | `300` |
-| `CROWSNEST__AUTH_MODE` | Authentication mode | enum | `anonymous`, `userpass`, `enhanced` |
+| `CROWSNEST__AUTH_MODE` | Authentication mode | enum | `anonymous`, `userpass`, `enhanced`, `azure` |
 | `CROWSNEST__AUTH_USERNAME` | Username (when AUTH_MODE=userpass) | string | `myuser` |
 | `CROWSNEST__AUTH_PASSWORD` | Password (when AUTH_MODE=userpass) | string | `mypass` |
 | `CROWSNEST__AUTH_METHOD` | Enhanced auth method (when AUTH_MODE=enhanced) | string | `SCRAM-SHA-1` |
 | `CROWSNEST__AUTH_DATA` | Enhanced auth data (when AUTH_MODE=enhanced) | string | |
+| `CROWSNEST__AUTH_SCOPE` | OAuth scope (when AUTH_MODE=azure) | string | `https://eventgrid.azure.net/.default` |
 | `CROWSNEST__USE_TLS` | Enable TLS encryption | bool | `true` |
 | `CROWSNEST__TRANSPORT` | Transport protocol | enum | `Tcp`, `WebSocket` |
 | `CROWSNEST__WEBSOCKET_PATH` | WebSocket path (when TRANSPORT=WebSocket) | string | `/mqtt` |

--- a/README.md
+++ b/README.md
@@ -200,9 +200,12 @@ Crow's Nest MQTT provides a command interface (likely accessible via a dedicated
 *   `:setuser <username>` - Set the username for MQTT authentication.
 *   `:setpass <password>` - Set the password for MQTT authentication.
 *   `:setauthmode <anonymous|userpass|enhanced|azure>` - Set the authentication mode. Use `azure` to connect to Azure Event Grid namespaces with Entra ID tokens via `DefaultAzureCredential`.
-*   `:setauthmethod <method>` - Set the authentication method for enhanced authentication (e.g., `SCRAM-SHA-1`, `K8S-SAT`).
+*   `:setauthmethod <method>` - Set the *enhanced-auth* method name (e.g., `SCRAM-SHA-1`, `K8S-SAT`). Applied only when the auth mode is `enhanced`. **Note:** this is distinct from `:setauthmode`; passing `anonymous`/`userpass`/`enhanced`/`azure` here is rejected because it's a common typo caused by the palette autocomplete.
 *   `:setauthdata <data>` - Set the authentication data for enhanced authentication (method-specific data).
 *   `:setauthscope <scope>` - Set the OAuth scope requested when Azure authentication mode is active. Defaults to `https://eventgrid.azure.net/.default`.
+*   `:setclientid [<client-id>]` - Set the MQTT Client ID (required for Azure Event Grid, must match a registered Client resource on the namespace). Omit the argument to clear.
+*   `:setsubscription [<topic-filter>]` - Set the MQTT topic filter for the client's initial subscription. Defaults to `#`. Azure Event Grid rejects `#`; use a filter that matches your Topic Space template (e.g. `sensors/#`). Omit the argument to reset to `#`.
+*   `:azurewhoami` - Print the identity (`upn`, `oid`, `name`, `appid`, `tenant`) that `DefaultAzureCredential` will use for Azure Event Grid. Use the values it prints to configure the `authenticationName` on the Event Grid Client resource.
 *   `:setusetls <true|false>` - Set whether to use TLS for the MQTT connection. When set to `true`, the client will connect using TLS, allow untrusted certificates, and ignore certificate errors.
 *   `:publish [topic] [@file|text]` - Open the publish window. Optionally pre-fill the topic (defaults to the selected topic) and payload from a file (`@path/to/file`) or inline text. The publish window is non-modal and supports all MQTT V5 properties.
 *   `[search_term]` - Any text entered without a `:` prefix is treated as a search term to filter messages.
@@ -314,6 +317,94 @@ The tests spawn the mock broker as a child process, connect a real MQTTnet v5
 client with OAUTH2-JWT, and assert that: (1) valid tokens are accepted, (2)
 CONNECTs without an `OAUTH2-JWT` method are rejected, and (3) client-initiated
 MQTT v5 `AUTH` re-authentication packets are received by the broker.
+
+### Troubleshooting Azure Event Grid connections
+
+If your `Azure` auth-mode connection is stuck in a reconnect loop with
+`NotAuthorized` in the status bar, work through these three checks in order —
+they cover the vast majority of setup issues.
+
+**1. Hostname must be the MQTT topic-space FQDN, not the HTTP Data Plane URL.**
+
+| ❌ Wrong (HTTP Data Plane) | ✅ Correct (MQTT topic space) |
+|---|---|
+| `https://mynamespace.northeurope-1.eventgrid.azure.net/api/events` | `mynamespace.northeurope-1.ts.eventgrid.azure.net` |
+
+The Azure portal shows both URLs in different blades. For MQTT you need the one
+with the **`.ts.`** infix, no scheme, and no path. The client auto-corrects
+common mistakes: pasting the HTTP URL strips `https://` / `/api/events` and
+rewrites the suffix on the fly, showing a status-bar note when it does.
+
+**2. Client ID must match a registered client on the namespace.**
+
+Azure Event Grid's MQTT broker maps the CONNECT packet's `Client ID` field to
+one of its Client resources (or a Client Authentication Name attribute rule).
+An empty / auto-generated GUID will be rejected. Set the Client ID via the
+settings pane or `:setclientid <name>` to the `name` of your Event Grid client
+resource, or to a value that matches your attribute rule.
+
+To figure out **which identity** to register the client for, run:
+
+```
+:azurewhoami
+```
+
+That command decodes the token `DefaultAzureCredential` would use and prints
+its `upn`, `oid`, `name`, `appid`, and `tenant` claims. Register an Event Grid
+Client whose **Client authentication name** matches your `oid` (Object ID is
+the most stable choice) or `upn`, then set the MQTT Client ID field to that
+client's `name`:
+
+```powershell
+$myOid = az ad signed-in-user show --query id -o tsv
+az eventgrid namespace client create `
+  --resource-group <rg> `
+  --namespace-name <namespace> `
+  --client-name my-cli-user `
+  --authentication-name $myOid `
+  --state Enabled
+```
+
+Then in Crow's Nest: `:setclientid my-cli-user`.
+
+**3. The signed-in identity needs an Event Grid RBAC role.**
+
+`DefaultAzureCredential` gets a token for whoever is signed in via `az login`,
+Visual Studio, managed identity, or an `AZURE_CLIENT_ID`+`AZURE_CLIENT_SECRET`
+env-var pair. That identity must have one of these roles on the namespace or
+topic-space:
+
+- `EventGrid TopicSpaces Publisher`
+- `EventGrid TopicSpaces Subscriber`
+
+Assign the role via `az role assignment create` or the portal's IAM blade. See
+the [Event Grid MQTT client auth docs](https://learn.microsoft.com/azure/event-grid/mqtt-client-authentication)
+for details.
+
+**4. Subscription filter must fit inside your Topic Space template.**
+
+After a successful CONNECT the client fires a single SUBSCRIBE. The default
+filter is `#` (all topics), which is what open brokers like EMQX or Mosquitto
+accept. **Azure Event Grid always rejects `#`** — the SUBACK carries
+`NotAuthorized` — because the filter has to be matched by a Permission Binding
+whose Topic Space template covers it. Set a narrower filter that fits your
+namespace's Topic Space:
+
+```
+:setsubscription sensors/#
+```
+
+or a specific topic template like `devices/+/telemetry`. Then reconnect. The
+subscription topic is also visible in the settings pane ("Subscription Topic")
+and is persisted to `settings.json`.
+
+**Other gotchas**
+
+- `Keep Alive` below ~30 seconds is rejected; the client bumps it to 30
+  automatically when you switch to Azure mode.
+- `Session Expiry` below 5 minutes with `Clean Session=true` causes the session
+  to expire before the first reconnect; the client bumps it to 3600 automatically.
+- `Use TLS` **must** be checked; Event Grid only accepts TLS on port 8883.
 
 ## dotnet Aspire
 

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -9,10 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MainApp\CrowsNestMqtt.App.csproj" />
+    <!-- Mock broker is launched at runtime as an executable, but we reference it so it builds alongside the AppHost. -->
+    <ProjectReference Include="..\..\tools\MockAzureEventGridBroker\MockAzureEventGridBroker.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <IsAspireProjectResource>false</IsAspireProjectResource>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,4 +1,9 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -59,6 +64,67 @@ var tlsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqt
     .WithEnvironment("CROWSNEST__USE_TLS", "true");
 sharedEnvVars(tlsInstance);
 
+// -------------------------------------------------------------------------
+// Azure Event Grid emulation (local testing only, no real Azure resources).
+// -------------------------------------------------------------------------
+// The mock broker accepts CONNECT packets whose AuthenticationMethod is
+// "OAUTH2-JWT" and whose AuthenticationData is a well-formed JWT. Signatures
+// are not verified, so any locally-signed JWT works. We synthesize a fresh JWT
+// per AppHost run and pass it to the client via CROWSNEST__AZURE_TOKEN_OVERRIDE,
+// which short-circuits DefaultAzureCredential.
+const int mockEgPort = 51883; // Fixed so the client can reference it via env var
+var mockBrokerDllPath = Path.GetFullPath(Path.Combine(
+    builder.AppHostDirectory,
+    "..", "..", "tools", "MockAzureEventGridBroker", "bin",
+    // Match the AppHost's own build configuration so 'dotnet run --configuration
+    // Release' picks up the Release DLL. Aspire's Environment.EnvironmentName is
+    // "Development" by default and doesn't reflect the actual build config, so
+    // infer it from where the AppHost assembly itself was loaded from.
+    Path.GetFileName(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar))
+        is "Release" or "release" ? "Release"
+        : Path.GetFileName(Path.GetDirectoryName(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar))!)
+            is "Release" or "release" ? "Release"
+        : "Debug",
+    "net10.0",
+    "CrowsNestMqtt.MockAzureEventGridBroker.dll"));
+var mockBrokerWorkingDir = Path.GetDirectoryName(mockBrokerDllPath)!;
+
+var mockEgBroker = builder.AddExecutable(
+        "mock-eg-broker",
+        "dotnet",
+        mockBrokerWorkingDir,
+        mockBrokerDllPath)
+    .WithEnvironment("MOCK_EG_HOST", "127.0.0.1")
+    .WithEnvironment("MOCK_EG_PORT", mockEgPort.ToString(System.Globalization.CultureInfo.InvariantCulture))
+    .WithEnvironment("MOCK_EG_USE_TLS", "true")
+    // Expose the listener as an Aspire endpoint so the dashboard shows the URL
+    // and downstream resources can reference it via .GetEndpoint("mqtts").
+    .WithEndpoint(port: mockEgPort, targetPort: mockEgPort, name: "mqtts", scheme: "tcp", isProxied: false);
+
+var mockEgEndpoint = mockEgBroker.GetEndpoint("mqtts");
+
+var devJwt = CreateDevJwt();
+
+var azureInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt-azure")
+    .WithReference(mockEgEndpoint)
+    .WaitFor(mockEgBroker)
+    .WithEnvironment("CROWSNEST__HOSTNAME", mockEgEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("CROWSNEST__PORT", mockEgEndpoint.Property(EndpointProperty.Port))
+    .WithEnvironment("CROWSNEST__USE_TLS", "true")
+    .WithEnvironment("CROWSNEST__AUTH_MODE", "azure")
+    .WithEnvironment("CROWSNEST__AUTH_SCOPE", "https://eventgrid.azure.net/.default")
+    .WithEnvironment("CROWSNEST__AZURE_TOKEN_OVERRIDE", devJwt);
+// Note: sharedEnvVars(azureInstance) intentionally NOT invoked — it would
+// overwrite CROWSNEST__AUTH_MODE=azure with "anonymous". We still want the
+// buffer/session defaults, so we set them individually here:
+azureInstance
+    .WithEnvironment("CROWSNEST__CLIENT_ID", "")
+    .WithEnvironment("CROWSNEST__KEEP_ALIVE_SECONDS", "0")
+    .WithEnvironment("CROWSNEST__CLEAN_SESSION", "true")
+    .WithEnvironment("CROWSNEST__SESSION_EXPIRY_SECONDS", "0")
+    .WithEnvironment("CROWSNEST__SUBSCRIPTION_QOS", "1")
+    .WithEnvironment("CROWSNEST__TOPIC_BUFFER_LIMITS", """[{"TopicFilter":"#","MaxSizeBytes":11048576}]""");
+
 // Add delayed test data sender that publishes sample data after broker is ready
 var toolsDir = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, "..", "..", "tools"));
 builder.AddExecutable("test-data-sender", "pwsh", toolsDir, "-File", "SendTestDataDelayed.ps1")
@@ -69,3 +135,33 @@ builder.AddExecutable("test-data-sender", "pwsh", toolsDir, "-File", "SendTestDa
     .WithEnvironment("MQTT_USE_TLS", "false");
 
 builder.Build().Run();
+
+// -------------------------------------------------------------------------
+// Development JWT synthesis for the Azure Event Grid emulation instance.
+// The mock broker does not verify the signature; any well-formed JWT works.
+// -------------------------------------------------------------------------
+static string CreateDevJwt()
+{
+    var keyBytes = new byte[32];
+    RandomNumberGenerator.Fill(keyBytes);
+    var credentials = new SigningCredentials(
+        new SymmetricSecurityKey(keyBytes),
+        SecurityAlgorithms.HmacSha256Signature);
+
+    var handler = new JwtSecurityTokenHandler();
+    var token = handler.CreateJwtSecurityToken(
+        issuer: "https://sts.local",
+        audience: "https://eventgrid.azure.net",
+        subject: new ClaimsIdentity(new[]
+        {
+            new Claim("sub", "dev-user"),
+            new Claim("scp", "EventGrid.Publish EventGrid.Receive"),
+        }),
+        notBefore: DateTime.UtcNow.AddMinutes(-5),
+        expires: DateTime.UtcNow.AddHours(1),
+        issuedAt: DateTime.UtcNow,
+        signingCredentials: credentials);
+
+    return handler.WriteToken(token);
+}
+

--- a/src/BusinessLogic/BusinessLogic.csproj
+++ b/src/BusinessLogic/BusinessLogic.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="MQTTnet" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 

--- a/src/BusinessLogic/Commands/CommandType.cs
+++ b/src/BusinessLogic/Commands/CommandType.cs
@@ -63,6 +63,12 @@ public enum CommandType
     GotoResponse,
     /// <summary> Publish a message to a topic. </summary>
     Publish,
+    /// <summary> Set the MQTT client identifier. </summary>
+    SetClientId,
+    /// <summary> Set the MQTT topic filter used for the client's initial subscription. </summary>
+    SetSubscriptionTopic,
+    /// <summary> Print the identity that will be used for Azure authentication. </summary>
+    AzureWhoAmI,
     /// <summary> Represents an unrecognized or invalid command. </summary>
     Unknown
 }

--- a/src/BusinessLogic/Commands/CommandType.cs
+++ b/src/BusinessLogic/Commands/CommandType.cs
@@ -53,6 +53,8 @@ public enum CommandType
     SetAuthMethod,
     /// <summary> Set the MQTT authentication data. </summary>
     SetAuthData,
+    /// <summary> Set the OAuth scope used by Azure authentication mode. </summary>
+    SetAuthScope,
     /// <summary> Set the MQTT TLS usage flag. </summary>
     SetUseTls,
     /// <summary> Delete retained messages from a topic and its subtopics. </summary>

--- a/src/BusinessLogic/Configutation/AuthenticationMode.cs
+++ b/src/BusinessLogic/Configutation/AuthenticationMode.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 [JsonDerivedType(typeof(AnonymousAuthenticationMode), typeDiscriminator: "anonymous")]
 [JsonDerivedType(typeof(UsernamePasswordAuthenticationMode), typeDiscriminator: "userpass")]
 [JsonDerivedType(typeof(EnhancedAuthenticationMode), typeDiscriminator: "enhanced")]
+[JsonDerivedType(typeof(AzureAuthenticationMode), typeDiscriminator: "azure")]
 public abstract record AuthenticationMode;
 
 /// <summary>

--- a/src/BusinessLogic/Configutation/AzureAuthenticationMode.cs
+++ b/src/BusinessLogic/Configutation/AzureAuthenticationMode.cs
@@ -1,0 +1,31 @@
+namespace CrowsNestMqtt.BusinessLogic.Configuration;
+
+/// <summary>
+/// Authentication mode for Azure Event Grid namespace MQTT brokers.
+/// Uses <c>Azure.Identity.DefaultAzureCredential</c> to obtain an Entra ID access token
+/// that is sent to the broker via MQTT v5 enhanced authentication with method
+/// <c>OAUTH2-JWT</c>. The token is fetched on every connection and proactively refreshed
+/// via MQTT v5 <c>AUTH</c> packets before it expires.
+/// </summary>
+/// <param name="Scope">
+/// Optional scope override. Defaults to <see cref="DefaultScope"/> when null or empty.
+/// </param>
+public sealed record AzureAuthenticationMode(string? Scope = null) : AuthenticationMode
+{
+    /// <summary>
+    /// Default OAuth scope used to acquire an Event Grid access token.
+    /// </summary>
+    public const string DefaultScope = "https://eventgrid.azure.net/.default";
+
+    /// <summary>
+    /// MQTT v5 enhanced-authentication method name used by Azure Event Grid.
+    /// </summary>
+    public const string AuthenticationMethod = "OAUTH2-JWT";
+
+    /// <summary>
+    /// Returns the effective scope, falling back to <see cref="DefaultScope"/> when
+    /// <see cref="Scope"/> is null or whitespace.
+    /// </summary>
+    public string EffectiveScope =>
+        string.IsNullOrWhiteSpace(Scope) ? DefaultScope : Scope!;
+}

--- a/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
+++ b/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
@@ -193,6 +193,7 @@ public sealed record EnvironmentSettingsOverrides
             "enhanced" => new EnhancedAuthenticationMode(
                 ReadString("AUTH_METHOD"),
                 ReadString("AUTH_DATA")),
+            "azure" => new AzureAuthenticationMode(ReadString("AUTH_SCOPE")),
             _ => null
         };
     }

--- a/src/BusinessLogic/Configutation/SettingsData.cs
+++ b/src/BusinessLogic/Configutation/SettingsData.cs
@@ -19,7 +19,8 @@ public record SettingsData(
     int TimeoutPeriodSeconds = 5,
     int SubscriptionQoS = 1,
     TransportProtocol Transport = TransportProtocol.Tcp,
-    string? WebSocketPath = null)
+    string? WebSocketPath = null,
+    string SubscriptionTopic = "#")
 {
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; init; } = new List<TopicBufferLimit>();
     /// <summary>

--- a/src/BusinessLogic/MqttConnectionSettings.cs
+++ b/src/BusinessLogic/MqttConnectionSettings.cs
@@ -39,4 +39,11 @@ public class MqttConnectionSettings
     /// Higher QoS reduces maximum message throughput.
     /// </summary>
     public int SubscriptionQoS { get; set; } = 1;
+    /// <summary>
+    /// MQTT topic filter used for the client's single startup subscription.
+    /// Defaults to <c>#</c> (all topics) which works for permissive brokers like EMQX
+    /// or Mosquitto. Azure Event Grid namespaces reject <c>#</c> — set this to a
+    /// filter that fits inside your Topic Space template (e.g. <c>sensors/#</c>).
+    /// </summary>
+    public string SubscriptionTopic { get; set; } = "#";
 }

--- a/src/BusinessLogic/MqttEngine.cs
+++ b/src/BusinessLogic/MqttEngine.cs
@@ -147,9 +147,13 @@ private MqttClientOptions? _currentOptions;
     {
         try
         {
+            var topicFilter = string.IsNullOrWhiteSpace(_settings.SubscriptionTopic)
+                ? "#"
+                : _settings.SubscriptionTopic;
+
             var subscribeOptions = new MqttClientSubscribeOptionsBuilder()
                 .WithTopicFilter(f =>
-                    f.WithTopic("#")
+                    f.WithTopic(topicFilter)
                      .WithQualityOfServiceLevel((MqttQualityOfServiceLevel)_settings.SubscriptionQoS)
                      .WithRetainAsPublished(true))
                 .Build();
@@ -160,9 +164,10 @@ private MqttClientOptions? _currentOptions;
             {
                 if (subResult.ResultCode > MqttClientSubscribeResultCode.GrantedQoS2)
                 {
-                    var errorMessage = $"Subscription to '{subResult.TopicFilter.Topic}' failed: {subResult.ResultCode}. Check broker permissions.";
+                    var baseError = $"Subscription to '{subResult.TopicFilter.Topic}' failed: {subResult.ResultCode}. Check broker permissions.";
+                    var errorMessage = DecorateSubscribeErrorForAzure(subResult.ResultCode, subResult.TopicFilter.Topic, baseError);
                     LogMessage?.Invoke(this, $"Failed to subscribe to topic '{subResult.TopicFilter.Topic}'. Result: {subResult.ResultCode}");
-                    
+
                     // Store error message to be included in disconnect event
                     _pendingErrorMessage = errorMessage;
                     
@@ -195,6 +200,29 @@ private MqttClientOptions? _currentOptions;
                 await _client.DisconnectAsync(new MqttClientDisconnectOptionsBuilder().Build(), CancellationToken.None).ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// When the SUBACK carries <c>NotAuthorized</c> against Azure Event Grid,
+    /// wildcard '#' subscriptions are almost always the cause — the broker only
+    /// accepts filters that fit inside the client's Topic Space template. Append
+    /// a targeted hint so the user knows exactly what to change.
+    /// </summary>
+    private string DecorateSubscribeErrorForAzure(
+        MqttClientSubscribeResultCode resultCode,
+        string topicFilter,
+        string baseMessage)
+    {
+        if (_settings.AuthMode is not AzureAuthenticationMode
+            || resultCode != MqttClientSubscribeResultCode.NotAuthorized)
+        {
+            return baseMessage;
+        }
+
+        return baseMessage
+            + $" Azure Event Grid rejects subscriptions outside your Topic Space template — '{topicFilter}' isn't matched by any permission binding on the namespace."
+            + " Set a narrower filter that matches your topic space (e.g. 'sensors/#' or 'devices/+/telemetry') via ':setsubscription <filter>' or the Subscription Topic setting, then reconnect."
+            + " If you own the namespace, verify that the Topic Space template and Permission Binding cover the filter you want.";
     }
 
     // Builds MqttClientOptions based on current settings.
@@ -1263,6 +1291,11 @@ private Task OnClientConnected(MqttClientConnectedEventArgs args)
         // Stop the token-refresh timer; if we reconnect a fresh token will be fetched.
         DisposeTokenRefreshTimer();
 
+        // Decorate obvious auth failures with Azure-specific troubleshooting.
+        // Only applies when Azure auth mode is active — other setups have their
+        // own diagnostic paths.
+        AppendAzureTroubleshootingHint(e);
+
         // If the disconnect was intentional (user clicked Disconnect/Cancel) or we are disposing,
         // then set the state to Disconnected and do not attempt to reconnect.
         if (_isDisposing || (_connectionCts?.IsCancellationRequested ?? true))
@@ -1297,5 +1330,59 @@ private Task OnClientConnected(MqttClientConnectedEventArgs args)
         _ = Task.Run(() => ReconnectAsync(_connectionCts.Token), _connectionCts.Token);
         
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// When we're running with Azure auth mode and the broker rejects the
+    /// connection with an auth-related reason code, prepend hints to
+    /// <c>_pendingErrorMessage</c> so the UI status bar surfaces something
+    /// actionable rather than the bare "NotAuthorized" the wire protocol carries.
+    /// </summary>
+    private void AppendAzureTroubleshootingHint(MqttClientDisconnectedEventArgs e)
+    {
+        if (_settings.AuthMode is not AzureAuthenticationMode)
+        {
+            return;
+        }
+
+        bool isAuthFailure =
+            e.Reason == MqttClientDisconnectReason.NotAuthorized
+            || e.Reason == MqttClientDisconnectReason.BadAuthenticationMethod
+            || (e.ConnectResult?.ResultCode is MqttClientConnectResultCode.NotAuthorized
+                                             or MqttClientConnectResultCode.BadAuthenticationMethod
+                                             or MqttClientConnectResultCode.BadUserNameOrPassword);
+
+        if (!isAuthFailure)
+        {
+            return;
+        }
+
+        var hostname = _settings.Hostname ?? string.Empty;
+        var hostSuffixOk = hostname.EndsWith(".ts.eventgrid.azure.net", StringComparison.OrdinalIgnoreCase);
+        var clientIdMissing = string.IsNullOrWhiteSpace(_settings.ClientId);
+
+        var hints = new System.Text.StringBuilder();
+        hints.Append("Azure Event Grid rejected the connection. Common causes: ");
+        var separatedHints = new List<string>();
+        if (clientIdMissing)
+        {
+            separatedHints.Add("Client ID is empty (must match a registered client on the namespace or a client-authentication-name attribute)");
+        }
+        if (!hostSuffixOk)
+        {
+            separatedHints.Add($"hostname '{hostname}' doesn't look like an Event Grid MQTT endpoint — expected pattern '<namespace>.<region>-1.ts.eventgrid.azure.net'");
+        }
+        separatedHints.Add("the signed-in identity may lack the 'EventGrid TopicSpaces Publisher/Subscriber' role");
+        separatedHints.Add("the OAuth scope should be 'https://eventgrid.azure.net/.default' (default)");
+        hints.Append(string.Join("; ", separatedHints));
+        hints.Append('.');
+
+        var hint = hints.ToString();
+        LogMessage?.Invoke(this, hint);
+
+        // Preserve existing pending error if any; append the hint on a new line.
+        _pendingErrorMessage = string.IsNullOrEmpty(_pendingErrorMessage)
+            ? hint
+            : _pendingErrorMessage + " " + hint;
     }
 } // End of MqttEngine class

--- a/src/BusinessLogic/MqttEngine.cs
+++ b/src/BusinessLogic/MqttEngine.cs
@@ -41,6 +41,7 @@ public class IdentifiedMqttApplicationMessageReceivedEventArgs : EventArgs // No
 public class MqttEngine : IMqttService // Implement the interface
 {
     private readonly IMqttClient _client;
+    private readonly Func<string, IAccessTokenProvider> _accessTokenProviderFactory;
     private MqttConnectionSettings _settings;
 private bool _isDisposing;
 private MqttClientOptions? _currentOptions;
@@ -53,7 +54,14 @@ private MqttClientOptions? _currentOptions;
     internal const long DefaultMaxTopicBufferSize = 1 * 1024 * 1024; // Changed to internal const
     private readonly object _bufferReconfigLock = new(); // Lock for reconfiguring existing topic buffers
     private string? _ownClientId;
-    
+
+    // Active access-token provider for the current connection (Azure auth only).
+    private IAccessTokenProvider? _activeAccessTokenProvider;
+    // Timer that proactively refreshes the OAuth token via MQTT v5 AUTH packets.
+    private Timer? _tokenRefreshTimer;
+    // Lead time before token expiry at which the refresh fires.
+    internal static readonly TimeSpan TokenRefreshLeadTime = TimeSpan.FromMinutes(5);
+
     // Track subscription error to preserve error message during disconnect
     private string? _pendingErrorMessage;
 
@@ -69,8 +77,22 @@ private MqttClientOptions? _currentOptions;
     public event EventHandler<string>? LogMessage;
 
     public MqttEngine(MqttConnectionSettings settings)
+        : this(settings, scope => new AzureAccessTokenProvider(scope))
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly constructor that allows injecting an access-token provider factory.
+    /// The factory receives the OAuth scope and returns the provider used during Azure
+    /// authentication. Production code uses <see cref="AzureAccessTokenProvider"/>.
+    /// </summary>
+    internal MqttEngine(
+        MqttConnectionSettings settings,
+        Func<string, IAccessTokenProvider> accessTokenProviderFactory)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _accessTokenProviderFactory = accessTokenProviderFactory
+            ?? throw new ArgumentNullException(nameof(accessTokenProviderFactory));
         _topicSpecificBufferLimits = EnsureDefaultTopicLimit(settings.TopicSpecificBufferLimits, settings.DefaultTopicBufferSizeBytes);
         var factory = new MqttClientFactory();
         _client = factory.CreateMqttClient();
@@ -175,8 +197,15 @@ private MqttClientOptions? _currentOptions;
         }
     }
 
-    // Builds MqttClientOptions based on current settings
-    private MqttClientOptions BuildMqttOptions()
+    // Builds MqttClientOptions based on current settings.
+    // Kept as a parameterless overload so existing reflection-based unit tests that
+    // invoke this method without arguments continue to work.
+    private MqttClientOptions BuildMqttOptions() => BuildMqttOptionsCore(prefetchedAzureToken: null);
+
+    // Builds MqttClientOptions based on current settings.
+    // When the auth mode is Azure, <paramref name="prefetchedAzureToken"/> must contain
+    // the access token to embed in the CONNECT packet.
+    private MqttClientOptions BuildMqttOptionsCore(AccessTokenResult? prefetchedAzureToken)
     {
         var builder = new MqttClientOptionsBuilder()
             .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
@@ -185,10 +214,14 @@ private MqttClientOptions? _currentOptions;
             .WithWillQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
             .WithTimeout(TimeSpan.FromSeconds(10));
 
+        // Azure Event Grid requires TLS on TCP at port 8883 — enforce here so callers
+        // can rely on the auth mode alone.
+        bool useTls = _settings.UseTls || _settings.AuthMode is AzureAuthenticationMode;
+
         // Configure transport
-        if (_settings.Transport == TransportProtocol.WebSocket)
+        if (_settings.Transport == TransportProtocol.WebSocket && _settings.AuthMode is not AzureAuthenticationMode)
         {
-            var scheme = _settings.UseTls ? "wss" : "ws";
+            var scheme = useTls ? "wss" : "ws";
             var path = string.IsNullOrWhiteSpace(_settings.WebSocketPath) ? "/mqtt" : _settings.WebSocketPath;
             var uri = $"{scheme}://{_settings.Hostname}:{_settings.Port}{path}";
             builder.WithWebSocketServer(o => o.WithUri(uri));
@@ -209,7 +242,7 @@ private MqttClientOptions? _currentOptions;
         }
 
         // TLS support
-        if (_settings.UseTls)
+        if (useTls)
         {
             var tlsOptions = new MqttClientTlsOptions
             {
@@ -241,6 +274,16 @@ private MqttClientOptions? _currentOptions;
                         Encoding.UTF8.GetBytes(enhancedAuth.AuthenticationData));
                 }
                 break;
+            case AzureAuthenticationMode:
+                if (prefetchedAzureToken is null)
+                {
+                    throw new InvalidOperationException(
+                        "Azure authentication mode requires a pre-fetched access token.");
+                }
+                builder.WithEnhancedAuthentication(
+                    AzureAuthenticationMode.AuthenticationMethod,
+                    Encoding.UTF8.GetBytes(prefetchedAzureToken.Value.Token));
+                break;
             case AnonymousAuthenticationMode:
                 // No credentials to add for anonymous mode
                 break;
@@ -266,18 +309,66 @@ public async Task ConnectAsync(CancellationToken cancellationToken = default)
     _linkedConnectionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _connectionCts.Token);
     var combinedToken = _linkedConnectionCts.Token;
 
+    DisposeTokenRefreshTimer();
+    _activeAccessTokenProvider = null;
+
     try
     {
         // Announce that we are starting the connection process.
         ConnectionStateChanged?.Invoke(this, new MqttConnectionStateChangedEventArgs(false, null, ConnectionStatusState.Connecting));
-        
-        _currentOptions = BuildMqttOptions();
+
+        AccessTokenResult? azureToken = null;
+        if (_settings.AuthMode is AzureAuthenticationMode azureMode)
+        {
+            try
+            {
+                _activeAccessTokenProvider = _accessTokenProviderFactory(azureMode.EffectiveScope);
+                azureToken = await _activeAccessTokenProvider
+                    .GetTokenAsync(combinedToken)
+                    .ConfigureAwait(false);
+                LogMessage?.Invoke(
+                    this,
+                    $"Acquired Azure access token (expires {azureToken.Value.ExpiresOn:O}).");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var msg = $"Failed to acquire Azure access token: {ex.Message}";
+                LogMessage?.Invoke(this, msg);
+                _pendingErrorMessage = msg;
+                ConnectionStateChanged?.Invoke(
+                    this,
+                    new MqttConnectionStateChangedEventArgs(false, ex, ConnectionStatusState.Disconnected, errorMessage: msg));
+                return;
+            }
+        }
+
+        _currentOptions = BuildMqttOptionsCore(azureToken);
+
+        // Wire up the enhanced authentication handler (for K8S-SAT logging and Azure
+        // OAUTH2-JWT token refresh). For Azure mode, pass the access token provider so
+        // server-initiated AUTH packets get a freshly minted token.
+        if (_settings.AuthMode is EnhancedAuthenticationMode || _settings.AuthMode is AzureAuthenticationMode)
+        {
+            var handler = new EnhancedAuthenticationHandler(_currentOptions, _activeAccessTokenProvider);
+            handler.Configure();
+        }
+
         _ownClientId = _currentOptions.ClientId;
         LogMessage?.Invoke(this, $"Attempting to connect to {_currentOptions.ChannelOptions} with ClientId '{_currentOptions.ClientId ?? "<generated>"}'.");
         
         // This call will either succeed and trigger OnClientConnected,
         // fail and trigger OnClientDisconnected, or be cancelled.
         await _client.ConnectAsync(_currentOptions, combinedToken).ConfigureAwait(false);
+
+        // Schedule proactive token refresh for Azure connections.
+        if (azureToken is not null && _activeAccessTokenProvider is not null)
+        {
+            ScheduleTokenRefresh(azureToken.Value.ExpiresOn);
+        }
     }
     catch (OperationCanceledException)
     {
@@ -292,12 +383,70 @@ public async Task ConnectAsync(CancellationToken cancellationToken = default)
     }
 }
 
+/// <summary>
+/// Schedules a one-shot timer that triggers an MQTT v5 AUTH round-trip
+/// <see cref="TokenRefreshLeadTime"/> before <paramref name="tokenExpiresOn"/>.
+/// </summary>
+private void ScheduleTokenRefresh(DateTimeOffset tokenExpiresOn)
+{
+    DisposeTokenRefreshTimer();
+
+    var delay = tokenExpiresOn - DateTimeOffset.UtcNow - TokenRefreshLeadTime;
+    if (delay < TimeSpan.FromSeconds(5))
+    {
+        // Token is already close to (or past) expiry; refresh immediately.
+        delay = TimeSpan.FromSeconds(1);
+    }
+
+    LogMessage?.Invoke(this, $"Scheduling Azure token refresh in {delay.TotalMinutes:F1} minutes.");
+    _tokenRefreshTimer = new Timer(_ => _ = RefreshAzureTokenAsync(), null, delay, Timeout.InfiniteTimeSpan);
+}
+
+private void DisposeTokenRefreshTimer()
+{
+    var timer = _tokenRefreshTimer;
+    _tokenRefreshTimer = null;
+    timer?.Dispose();
+}
+
+private async Task RefreshAzureTokenAsync()
+{
+    var provider = _activeAccessTokenProvider;
+    if (provider is null || !_client.IsConnected)
+    {
+        return;
+    }
+
+    try
+    {
+        LogMessage?.Invoke(this, "Refreshing Azure access token via MQTT v5 AUTH packet.");
+        var refreshed = await provider.GetTokenAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var data = new MqttEnhancedAuthenticationExchangeData
+        {
+            AuthenticationData = Encoding.UTF8.GetBytes(refreshed.Token),
+            ReasonCode = MQTTnet.Protocol.MqttAuthenticateReasonCode.ReAuthenticate,
+        };
+
+        await _client.SendEnhancedAuthenticationExchangeDataAsync(data, CancellationToken.None).ConfigureAwait(false);
+
+        LogMessage?.Invoke(this, $"Azure access token refreshed (new expiry {refreshed.ExpiresOn:O}).");
+        ScheduleTokenRefresh(refreshed.ExpiresOn);
+    }
+    catch (Exception ex)
+    {
+        LogMessage?.Invoke(this, $"Proactive token refresh failed: {ex.Message}. Will rely on reconnect.");
+    }
+}
+
 public async Task DisconnectAsync(CancellationToken cancellationToken = default)
 {
     // This method now has a single responsibility: to signal that the user wants to stop.
     // It cancels the master token for this connection cycle.
     LogMessage?.Invoke(this, "Disconnect/Cancel requested by user.");
     _connectionCts?.Cancel();
+    DisposeTokenRefreshTimer();
+    _activeAccessTokenProvider = null;
 
     // If the client is already connected, we can also initiate a graceful disconnect.
     // The OnClientDisconnected handler will still fire, but this can speed up the process.
@@ -1051,6 +1200,7 @@ public async Task DisconnectAsync(CancellationToken cancellationToken = default)
             _isDisposing = true;
 
             _messageProcessingTimer.Dispose();
+            DisposeTokenRefreshTimer();
             _pendingMessages.Clear();
 
             _client.ApplicationMessageReceivedAsync -= HandleIncomingMessageAsync;
@@ -1109,6 +1259,9 @@ private Task OnClientConnected(MqttClientConnectedEventArgs args)
     private Task OnClientDisconnected(MqttClientDisconnectedEventArgs e)
     {
         LogMessage?.Invoke(this, $"Disconnected: {e.ReasonString}. Client Was Connected: {e.ClientWasConnected}");
+
+        // Stop the token-refresh timer; if we reconnect a fresh token will be fetched.
+        DisposeTokenRefreshTimer();
 
         // If the disconnect was intentional (user clicked Disconnect/Cancel) or we are disposing,
         // then set the state to Disconnected and do not attempt to reconnect.

--- a/src/BusinessLogic/Services/AzureAccessTokenProvider.cs
+++ b/src/BusinessLogic/Services/AzureAccessTokenProvider.cs
@@ -1,0 +1,105 @@
+namespace CrowsNestMqtt.BusinessLogic.Services;
+
+using System.IdentityModel.Tokens.Jwt;
+using Azure.Core;
+using Azure.Identity;
+using CrowsNestMqtt.Utils;
+
+/// <summary>
+/// <see cref="IAccessTokenProvider"/> backed by
+/// <see cref="DefaultAzureCredential"/>. Probes environment variables, managed identity,
+/// Visual Studio, Azure CLI, Azure PowerShell, and interactive browser in order.
+/// Tokens are returned directly from the underlying credential, which performs its own
+/// caching according to the Azure SDK conventions.
+///
+/// <para>
+/// <b>Local-testing override:</b> when the <c>CROWSNEST__AZURE_TOKEN_OVERRIDE</c>
+/// environment variable is set, the value is returned as-is and
+/// <see cref="DefaultAzureCredential"/> is bypassed entirely. This is intended for
+/// running the Aspire host with the bundled mock Azure Event Grid broker (which does
+/// not verify JWT signatures) and MUST NOT be set in production. Token expiry is
+/// derived from the JWT <c>exp</c> claim when the override value parses as a JWT;
+/// otherwise a 1-hour fallback lifetime is used so the refresh timer still fires.
+/// </para>
+/// </summary>
+public sealed class AzureAccessTokenProvider : IAccessTokenProvider
+{
+    /// <summary>
+    /// Environment variable that short-circuits credential acquisition and returns
+    /// a pre-issued token. Intended for local Aspire testing only.
+    /// </summary>
+    public const string TokenOverrideEnvVar = "CROWSNEST__AZURE_TOKEN_OVERRIDE";
+
+    private readonly TokenCredential _credential;
+    private readonly string _scope;
+
+    /// <summary>
+    /// Creates a provider that requests tokens for the given OAuth scope.
+    /// </summary>
+    /// <param name="scope">The OAuth scope, e.g. <c>https://eventgrid.azure.net/.default</c>.</param>
+    public AzureAccessTokenProvider(string scope)
+        : this(scope, new DefaultAzureCredential(includeInteractiveCredentials: true))
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly constructor that accepts an arbitrary <see cref="TokenCredential"/>.
+    /// </summary>
+    public AzureAccessTokenProvider(string scope, TokenCredential credential)
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            throw new ArgumentException("Scope must not be null or whitespace.", nameof(scope));
+        }
+
+        _scope = scope;
+        _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+    }
+
+    /// <inheritdoc />
+    public async Task<AccessTokenResult> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var overrideToken = Environment.GetEnvironmentVariable(TokenOverrideEnvVar);
+        if (!string.IsNullOrEmpty(overrideToken))
+        {
+            var expiresOn = ReadJwtExpiryOrFallback(overrideToken);
+            AppLogger.Information(
+                $"Using {TokenOverrideEnvVar} for Azure token (LOCAL TESTING ONLY). Expires at {expiresOn:O}.");
+            return new AccessTokenResult(overrideToken, expiresOn);
+        }
+
+        AppLogger.Information($"Acquiring Azure access token for scope {_scope}.");
+        var token = await _credential
+            .GetTokenAsync(new TokenRequestContext(new[] { _scope }), cancellationToken)
+            .ConfigureAwait(false);
+
+        AppLogger.Information(
+            $"Azure access token acquired. Expires at {token.ExpiresOn:O}.");
+
+        return new AccessTokenResult(token.Token, token.ExpiresOn);
+    }
+
+    /// <summary>
+    /// Attempts to read the <c>exp</c> claim from <paramref name="tokenString"/> as a
+    /// JWT. Falls back to <c>UtcNow + 1h</c> when the value is not a valid JWT or
+    /// has no <c>exp</c> claim.
+    /// </summary>
+    internal static DateTimeOffset ReadJwtExpiryOrFallback(string tokenString)
+    {
+        try
+        {
+            var jwt = new JwtSecurityTokenHandler().ReadJwtToken(tokenString);
+            if (jwt.ValidTo != default)
+            {
+                return new DateTimeOffset(jwt.ValidTo, TimeSpan.Zero);
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException)
+        {
+            AppLogger.Warning(
+                $"{TokenOverrideEnvVar} value is not a valid JWT; using fallback 1-hour expiry. Error: {ex.Message}");
+        }
+
+        return DateTimeOffset.UtcNow.AddHours(1);
+    }
+}

--- a/src/BusinessLogic/Services/CommandParserService.cs
+++ b/src/BusinessLogic/Services/CommandParserService.cs
@@ -303,12 +303,12 @@ public class CommandParserService : ICommandParserService
                 if (arguments.Count == 1)
                 {
                     string mode = arguments[0].ToLowerInvariant();
-                    if (mode == "anonymous" || mode == "userpass" || mode == "enhanced")
+                    if (mode == "anonymous" || mode == "userpass" || mode == "enhanced" || mode == "azure")
                     {
                         return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetAuthMode, arguments));
                     }
                 }
-                return CommandResult.Failure("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced>");
+                return CommandResult.Failure("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced|azure>");
 
             case "setauthmethod":
                 if (arguments.Count == 1)
@@ -323,6 +323,13 @@ public class CommandParserService : ICommandParserService
                     return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetAuthData, arguments));
                 }
                 return CommandResult.Failure("Invalid arguments for :setauthdata. Expected: :setauthdata <data>");
+
+            case "setauthscope":
+                if (arguments.Count == 1 && !string.IsNullOrWhiteSpace(arguments[0]))
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetAuthScope, arguments));
+                }
+                return CommandResult.Failure("Invalid arguments for :setauthscope. Expected: :setauthscope <scope>");
 
             case "setusetls":
                 if (arguments.Count == 1)

--- a/src/BusinessLogic/Services/CommandParserService.cs
+++ b/src/BusinessLogic/Services/CommandParserService.cs
@@ -331,6 +331,39 @@ public class CommandParserService : ICommandParserService
                 }
                 return CommandResult.Failure("Invalid arguments for :setauthscope. Expected: :setauthscope <scope>");
 
+            case "setclientid":
+                // :setclientid <id>   → set the client id to <id>
+                // :setclientid         → clear the client id (auto-generated)
+                if (arguments.Count == 0)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetClientId, new List<string>()));
+                }
+                if (arguments.Count == 1)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetClientId, arguments));
+                }
+                return CommandResult.Failure("Invalid arguments for :setclientid. Expected: :setclientid [<client-id>]");
+
+            case "setsubscription":
+                // :setsubscription <filter>  → subscribe using <filter>
+                // :setsubscription           → reset to '#'
+                if (arguments.Count == 0)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetSubscriptionTopic, new List<string>()));
+                }
+                if (arguments.Count == 1 && !string.IsNullOrWhiteSpace(arguments[0]))
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetSubscriptionTopic, arguments));
+                }
+                return CommandResult.Failure("Invalid arguments for :setsubscription. Expected: :setsubscription [<topic-filter>]");
+
+            case "azurewhoami":
+                if (arguments.Count == 0)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.AzureWhoAmI, new List<string>()));
+                }
+                return CommandResult.Failure("Invalid arguments for :azurewhoami. Expected: :azurewhoami");
+
             case "setusetls":
                 if (arguments.Count == 1)
                 {

--- a/src/BusinessLogic/Services/EnhancedAuthenticationHandler.cs
+++ b/src/BusinessLogic/Services/EnhancedAuthenticationHandler.cs
@@ -1,38 +1,46 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
 
+using CrowsNestMqtt.BusinessLogic.Configuration;
 using CrowsNestMqtt.Utils;
 using MQTTnet;
+using MQTTnet.Protocol;
 
 namespace CrowsNestMqtt.BusinessLogic.Services;
 
 public class EnhancedAuthenticationHandler: IMqttEnhancedAuthenticationHandler
 {
     private readonly MqttClientOptions _mqttClientOptions;
+    private readonly IAccessTokenProvider? _accessTokenProvider;
 
     public EnhancedAuthenticationHandler(MqttClientOptions mqttClientOptions)
+        : this(mqttClientOptions, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a handler that can refresh OAuth tokens on demand using the provided
+    /// access-token provider. Required when the connection uses
+    /// <see cref="AzureAuthenticationMode.AuthenticationMethod"/> ("OAUTH2-JWT").
+    /// </summary>
+    public EnhancedAuthenticationHandler(
+        MqttClientOptions mqttClientOptions,
+        IAccessTokenProvider? accessTokenProvider)
     {
         _mqttClientOptions = mqttClientOptions;
+        _accessTokenProvider = accessTokenProvider;
     }
 
     public void Configure()
     {
-
         if (_mqttClientOptions.AuthenticationMethod == "K8S-SAT" && _mqttClientOptions.AuthenticationData.Length > 0)
         {
-            var handler = new JwtSecurityTokenHandler();
-            var jwtTokenAsString = Encoding.UTF8.GetString(_mqttClientOptions.AuthenticationData);
-            var jwtSecurityToken = handler.ReadJwtToken(jwtTokenAsString);
-
-            var now = System.DateTime.UtcNow;
-            if (jwtSecurityToken.ValidTo > now)
-            {
-                AppLogger.Information($"Enhanced Authentication: Token is valid until {jwtSecurityToken.ValidTo}.");
-            }
-            else
-            {
-                AppLogger.Warning($"Enhanced Authentication: Token has expired on {jwtSecurityToken.ValidTo}.");
-            }
+            LogJwtValidity(_mqttClientOptions.AuthenticationData, "K8S-SAT");
+        }
+        else if (_mqttClientOptions.AuthenticationMethod == AzureAuthenticationMode.AuthenticationMethod
+                 && _mqttClientOptions.AuthenticationData.Length > 0)
+        {
+            LogJwtValidity(_mqttClientOptions.AuthenticationData, AzureAuthenticationMode.AuthenticationMethod);
         }
         else
         {
@@ -42,9 +50,65 @@ public class EnhancedAuthenticationHandler: IMqttEnhancedAuthenticationHandler
         _mqttClientOptions.EnhancedAuthenticationHandler = this;
     }
 
-    public Task HandleEnhancedAuthenticationAsync(MqttEnhancedAuthenticationEventArgs eventArgs)
+    public async Task HandleEnhancedAuthenticationAsync(MqttEnhancedAuthenticationEventArgs eventArgs)
     {
-        AppLogger.Information($"Enhanced Authentication: {eventArgs.ReasonString}");
-        return Task.CompletedTask;
+        AppLogger.Information(
+            $"Enhanced Authentication: server-initiated AUTH packet received (method={eventArgs.AuthenticationMethod}, reason={eventArgs.ReasonCode}).");
+
+        if (eventArgs.AuthenticationMethod == AzureAuthenticationMode.AuthenticationMethod
+            && _accessTokenProvider is not null)
+        {
+            try
+            {
+                var token = await _accessTokenProvider
+                    .GetTokenAsync(eventArgs.CancellationToken)
+                    .ConfigureAwait(false);
+
+                var tokenBytes = Encoding.UTF8.GetBytes(token.Token);
+                await eventArgs
+                    .SendAsync(
+                        new SendMqttEnhancedAuthenticationDataOptions
+                        {
+                            Data = tokenBytes,
+                        },
+                        eventArgs.CancellationToken)
+                    .ConfigureAwait(false);
+
+                AppLogger.Information(
+                    $"Enhanced Authentication: refreshed OAuth token sent to broker (new expiry {token.ExpiresOn:O}).");
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Enhanced Authentication: failed to refresh OAuth token.");
+            }
+        }
+    }
+
+    private static void LogJwtValidity(byte[] data, string method)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwtTokenAsString = Encoding.UTF8.GetString(data);
+            var jwtSecurityToken = handler.ReadJwtToken(jwtTokenAsString);
+
+            var now = DateTime.UtcNow;
+            if (jwtSecurityToken.ValidTo > now)
+            {
+                AppLogger.Information(
+                    $"Enhanced Authentication ({method}): Token is valid until {jwtSecurityToken.ValidTo:O}.");
+            }
+            else
+            {
+                AppLogger.Warning(
+                    $"Enhanced Authentication ({method}): Token has expired on {jwtSecurityToken.ValidTo:O}.");
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warning(
+                ex,
+                $"Enhanced Authentication ({method}): Failed to parse token as JWT.");
+        }
     }
 }

--- a/src/BusinessLogic/Services/IAccessTokenProvider.cs
+++ b/src/BusinessLogic/Services/IAccessTokenProvider.cs
@@ -1,0 +1,21 @@
+namespace CrowsNestMqtt.BusinessLogic.Services;
+
+/// <summary>
+/// Represents an OAuth access token together with its expiration timestamp.
+/// </summary>
+/// <param name="Token">The raw access token string.</param>
+/// <param name="ExpiresOn">UTC timestamp at which the token expires.</param>
+public readonly record struct AccessTokenResult(string Token, DateTimeOffset ExpiresOn);
+
+/// <summary>
+/// Abstraction over an access-token source so authentication flows can be unit-tested
+/// without the Azure SDK.
+/// </summary>
+public interface IAccessTokenProvider
+{
+    /// <summary>
+    /// Returns a current (non-expired) access token. Implementations may cache results
+    /// internally and return a cached token until it is close to expiring.
+    /// </summary>
+    Task<AccessTokenResult> GetTokenAsync(CancellationToken cancellationToken = default);
+}

--- a/src/BusinessLogic/Services/MqttHostnameNormalizer.cs
+++ b/src/BusinessLogic/Services/MqttHostnameNormalizer.cs
@@ -1,0 +1,125 @@
+namespace CrowsNestMqtt.BusinessLogic.Services;
+
+using System;
+using System.Globalization;
+
+/// <summary>
+/// Result of normalizing an MQTT-style hostname input.
+/// </summary>
+/// <param name="Hostname">The cleaned hostname (no scheme, no path, no port).</param>
+/// <param name="Port">The port extracted from the input, or <c>null</c> when none was present.</param>
+/// <param name="Notes">
+/// Human-readable notes describing every non-trivial transformation applied
+/// (e.g. "stripped 'https://' scheme"). Empty when the input was already clean.
+/// </param>
+public readonly record struct NormalizedMqttHostname(string Hostname, int? Port, IReadOnlyList<string> Notes)
+{
+    /// <summary>True when the normalizer actually changed the input.</summary>
+    public bool WasChanged => Notes.Count > 0;
+}
+
+/// <summary>
+/// Cleans user-supplied hostname strings so callers can accept the many shapes
+/// people paste from browser address bars, Azure portal blades, and MQTT
+/// tutorials, and always end up with a plain hostname the MQTT layer can use.
+///
+/// The normalizer:
+///  <list type="bullet">
+///   <item>strips URL schemes (<c>https://</c>, <c>http://</c>, <c>mqtt://</c>, <c>mqtts://</c>, <c>ws://</c>, <c>wss://</c>, <c>tcp://</c>);</item>
+///   <item>strips anything after the first <c>/</c> (e.g. <c>/api/events</c>);</item>
+///   <item>extracts a trailing <c>:&lt;port&gt;</c> and reports it separately;</item>
+///   <item>rewrites <c>&lt;ns&gt;.&lt;region&gt;-N.eventgrid.azure.net</c> → <c>&lt;ns&gt;.&lt;region&gt;-N.ts.eventgrid.azure.net</c> (Azure Event Grid HTTP data-plane → MQTT topic-space suffix mapping);</item>
+///   <item>trims whitespace.</item>
+///  </list>
+/// It never invents a hostname from thin air: null / empty inputs pass through
+/// unchanged with no notes.
+/// </summary>
+public static class MqttHostnameNormalizer
+{
+    private static readonly string[] KnownSchemes =
+    {
+        "https://", "http://", "mqtts://", "mqtt://", "wss://", "ws://", "tcp://",
+    };
+
+    private const string EventGridHttpSuffix = ".eventgrid.azure.net";
+    private const string EventGridMqttSuffix = ".ts.eventgrid.azure.net";
+
+    /// <summary>
+    /// Normalizes <paramref name="input"/>. Returns the original string in the
+    /// <see cref="NormalizedMqttHostname.Hostname"/> slot when the value is
+    /// null / whitespace so callers don't have to special-case that.
+    /// </summary>
+    public static NormalizedMqttHostname Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return new NormalizedMqttHostname(input ?? string.Empty, null, Array.Empty<string>());
+        }
+
+        var notes = new List<string>();
+        var work = input.Trim();
+        if (work.Length != input.Length)
+        {
+            notes.Add("trimmed surrounding whitespace");
+        }
+
+        // 1. Strip a known URL scheme.
+        foreach (var scheme in KnownSchemes)
+        {
+            if (work.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                work = work.Substring(scheme.Length);
+                notes.Add($"stripped '{scheme}' scheme");
+                break;
+            }
+        }
+
+        // 2. Strip anything after the first '/' (path / query).
+        var slashIndex = work.IndexOf('/');
+        if (slashIndex >= 0)
+        {
+            var stripped = work.Substring(slashIndex);
+            work = work.Substring(0, slashIndex);
+            notes.Add($"stripped path '{stripped}'");
+        }
+
+        // 3. Strip a userinfo prefix if any (rare, but 'user@host:port' is legal in URIs).
+        var atIndex = work.IndexOf('@');
+        if (atIndex >= 0)
+        {
+            work = work.Substring(atIndex + 1);
+            notes.Add("stripped userinfo prefix");
+        }
+
+        // 4. Extract a trailing ':port'.
+        int? extractedPort = null;
+        var colonIndex = work.LastIndexOf(':');
+        if (colonIndex > 0
+            && colonIndex < work.Length - 1
+            && int.TryParse(
+                work.AsSpan(colonIndex + 1),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsedPort)
+            && parsedPort is > 0 and <= 65535)
+        {
+            extractedPort = parsedPort;
+            work = work.Substring(0, colonIndex);
+            notes.Add($"extracted port {parsedPort}");
+        }
+
+        // 5. Azure Event Grid: rewrite the HTTP data-plane suffix to the MQTT
+        //    topic-space suffix. The rewrite is guarded on NOT already having
+        //    the .ts. infix to avoid duplication.
+        if (work.EndsWith(EventGridHttpSuffix, StringComparison.OrdinalIgnoreCase)
+            && !work.EndsWith(EventGridMqttSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var prefix = work.Substring(0, work.Length - EventGridHttpSuffix.Length);
+            var rewritten = prefix + EventGridMqttSuffix;
+            notes.Add($"rewrote Event Grid HTTP suffix to MQTT topic-space suffix ('{work}' → '{rewritten}')");
+            work = rewritten;
+        }
+
+        return new NormalizedMqttHostname(work, extractedPort, notes);
+    }
+}

--- a/src/UI/ViewModels/HostnameNormalizedEventArgs.cs
+++ b/src/UI/ViewModels/HostnameNormalizedEventArgs.cs
@@ -1,0 +1,43 @@
+namespace CrowsNestMqtt.UI.ViewModels;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Event payload for <see cref="SettingsViewModel.HostnameNormalized"/>.
+/// Fires when the hostname setter transformed user input (stripped a scheme,
+/// extracted a port, rewrote the Event Grid HTTP suffix, etc.).
+/// </summary>
+public sealed class HostnameNormalizedEventArgs : EventArgs
+{
+    public HostnameNormalizedEventArgs(string original, string cleaned, int? extractedPort, IReadOnlyList<string> notes)
+    {
+        Original = original;
+        Cleaned = cleaned;
+        ExtractedPort = extractedPort;
+        Notes = notes;
+    }
+
+    /// <summary>The raw value the user assigned (before normalization).</summary>
+    public string Original { get; }
+
+    /// <summary>The cleaned hostname now stored on the ViewModel.</summary>
+    public string Cleaned { get; }
+
+    /// <summary>Port extracted from the input, or null when none was present.</summary>
+    public int? ExtractedPort { get; }
+
+    /// <summary>Human-readable descriptions of every transformation applied.</summary>
+    public IReadOnlyList<string> Notes { get; }
+
+    /// <summary>Compose a single-sentence status-bar summary.</summary>
+    public string ToStatusMessage()
+    {
+        var parts = new List<string> { $"Corrected hostname to '{Cleaned}'" };
+        if (ExtractedPort is int p)
+        {
+            parts.Add($"(port {p} extracted from input)");
+        }
+        return string.Join(' ', parts) + ".";
+    }
+}

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -3061,20 +3061,28 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                         }
                         else if (mode == "enhanced")
                         {
-                            this.Settings.AuthenticationMethod = "Enhanced Authentication";
-                            StatusBarText = "Authentication method set to 'Enhanced Authentication'. Settings will be saved.";
-                            Log.Information("Authentication method set to 'Enhanced Authentication' via command.");
+                            this.Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Enhanced;
+                            StatusBarText = "Authentication mode set to Enhanced. Settings will be saved.";
+                            Log.Information("Authentication mode set to Enhanced via command.");
+                        }
+                        else if (mode == "azure")
+                        {
+                            this.Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+                            StatusBarText =
+                                "Authentication mode set to Azure (OAUTH2-JWT via DefaultAzureCredential). "
+                                + "Port 8883, TLS, and TCP transport have been enabled. Settings will be saved.";
+                            Log.Information("Authentication mode set to Azure via command.");
                         }
                         else
                         {
                             // This case should ideally be caught by CommandParserService, but good for robustness
-                            StatusBarText = "Error: Invalid argument for :setauthmode. Expected <anonymous|userpass|enhanced>.";
+                            StatusBarText = "Error: Invalid argument for :setauthmode. Expected <anonymous|userpass|enhanced|azure>.";
                             Log.Warning("Invalid argument for SetAuthMode command: {Argument}", command.Arguments[0]);
                         }
                     }
                     else
                     {
-                        StatusBarText = "Error: :setauthmode requires exactly one argument <anonymous|userpass|enhanced>.";
+                        StatusBarText = "Error: :setauthmode requires exactly one argument <anonymous|userpass|enhanced|azure>.";
                         Log.Warning("Invalid arguments for SetAuthMode command.");
                     }
                     break;
@@ -3120,6 +3128,19 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                     {
                         StatusBarText = "Error: :setauthdata requires exactly one argument <data>.";
                         Log.Warning("Invalid arguments for SetAuthData command.");
+                    }
+                    break;
+                case CommandType.SetAuthScope:
+                    if (command.Arguments.Count == 1 && !string.IsNullOrWhiteSpace(command.Arguments[0]))
+                    {
+                        this.Settings.AuthenticationScope = command.Arguments[0];
+                        StatusBarText = $"Azure OAuth scope set to '{command.Arguments[0]}'. Settings will be saved.";
+                        Log.Information("Azure OAuth scope set via command: {Scope}", command.Arguments[0]);
+                    }
+                    else
+                    {
+                        StatusBarText = "Error: :setauthscope requires exactly one argument <scope>.";
+                        Log.Warning("Invalid arguments for SetAuthScope command.");
                     }
                     break;
                 case CommandType.SetUseTls:
@@ -3178,9 +3199,10 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         { "view", (":view <raw|json|image>", "Switches the payload view between raw text, JSON tree and image.") },
         { "setuser", (":setuser <username>", "Sets MQTT username. Switches to Username/Password auth if current mode is Anonymous.") },
         { "setpass", (":setpass <password>", "Sets MQTT password. Switches to Username/Password auth if current mode is Anonymous.") },
-        { "setauthmode", (":setauthmode <anonymous|userpass|enhanced>", "Sets the MQTT authentication mode.") },
+        { "setauthmode", (":setauthmode <anonymous|userpass|enhanced|azure>", "Sets the MQTT authentication mode. 'azure' uses Entra ID (DefaultAzureCredential) to obtain an OAUTH2-JWT token for Azure Event Grid namespaces.") },
         { "setauthmethod", (":setauthmethod <method>", "Sets the authentication method for enhanced authentication (e.g., SCRAM-SHA-1, K8S-SAT).") },
         { "setauthdata", (":setauthdata <data>", "Sets the authentication data for enhanced authentication (method-specific data).") },
+        { "setauthscope", (":setauthscope <scope>", "Sets the OAuth scope requested when Azure authentication mode is active. Defaults to https://eventgrid.azure.net/.default.") },
         { "setusetls", (":setusetls <true|false>", "Sets whether to use TLS for MQTT connections. true = enable TLS, false = disable TLS.") },
         { "deletetopic", (":deletetopic [topic-pattern] [--confirm]", "Deletes retained messages from a topic and its subtopics by publishing empty retained messages. Uses selected topic if no pattern specified.") },
         { "gotoresponse", (":gotoresponse", "Navigates to the response message for the currently selected MQTT v5 request message.") },
@@ -3269,6 +3291,17 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         if (command.Arguments.Count == 0)
         {
             // :connect (use all from settings)
+            // If the saved hostname is an Event Grid namespace but auth mode isn't yet
+            // Azure, auto-switch so the connection actually works.
+            if (IsAzureEventGridHost(Settings.Hostname)
+                && Settings.SelectedAuthMode != SettingsViewModel.AuthModeSelection.Azure)
+            {
+                Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+                Log.Information(
+                    "Detected Azure Event Grid host '{Host}' in settings; switching to Azure auth mode.",
+                    Settings.Hostname);
+            }
+
             StatusBarText = $"Attempting to connect to {Settings.Hostname}:{Settings.Port}...";
             ConnectCommand.Execute().Subscribe(
                 _ => StatusBarText = $"Successfully initiated connection to {Settings.Hostname}:{Settings.Port}.",
@@ -3331,6 +3364,21 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             Settings.Hostname = host;
             Settings.Port = port;
 
+            // Azure Event Grid namespace MQTT hostnames end with .ts.eventgrid.azure.net.
+            // Auto-switch to Azure auth mode so the user doesn't need to run
+            // :setauthmode azure / :setusetls true separately.
+            if (IsAzureEventGridHost(host))
+            {
+                if (Settings.SelectedAuthMode != SettingsViewModel.AuthModeSelection.Azure)
+                {
+                    Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+                    Log.Information("Detected Azure Event Grid host '{Host}'; switching to Azure auth mode.", host);
+                }
+                // SelectedAuthMode.Azure setter already forces UseTls=true, Port=8883, Transport=Tcp.
+                // Restore the user-supplied port if they explicitly specified one other than 8883.
+                Settings.Port = port;
+            }
+
             StatusBarText = $"Attempting to connect to {host}:{port}...";
             ConnectCommand.Execute().Subscribe(
                 _ => StatusBarText = $"Successfully initiated connection to {host}:{port}.",
@@ -3348,6 +3396,19 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             Log.Warning("Invalid argument count for :connect command: {Count}", command.Arguments.Count);
             return;
         }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="host"/> looks like an Azure Event Grid namespace
+    /// MQTT broker (matches the well-known suffix <c>.ts.eventgrid.azure.net</c>).
+    /// </summary>
+    internal static bool IsAzureEventGridHost(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+        return host.EndsWith(".ts.eventgrid.azure.net", StringComparison.OrdinalIgnoreCase);
     }
 
     private void Export(ParsedCommand command)

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -66,6 +66,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     private readonly List<string> _availableCommands; // Added list of commands for suggestions
     private readonly IReactiveGlobalHook? _globalHook; // Added SharpHook global hook
     private readonly IDisposable? _globalHookSubscription; // Added subscription for the hook
+    private readonly Func<string, IAccessTokenProvider> _azureTokenProviderFactory; // For :azurewhoami
     private bool _disposedValue; // For IDisposable pattern
     private string? _normalizedSelectedPath; // Normalized selected topic path (no trailing slash)
     private bool _isUpdatingSelectedNode; // Guard against re-entrancy in SelectedNode setter
@@ -753,7 +754,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
     /// Sets up placeholder data and starts the UI update timer.
     /// </summary>
     // Constructor now requires ICommandParserService
-    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, EnvironmentSettingsOverrides? environmentOverrides = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null)
+    public MainViewModel(ICommandParserService commandParserService, IMqttService? mqttService = null, IDeleteTopicService? deleteTopicService = null, IMessageCorrelationService? correlationService = null, IResponseIconService? iconService = null, EnvironmentSettingsOverrides? environmentOverrides = null, IScheduler? uiScheduler = null, IPublishHistoryService? publishHistoryService = null, IFileAutoCompleteService? fileAutoCompleteService = null, Func<string, IAccessTokenProvider>? azureTokenProviderFactory = null)
     {
         _commandParserService = commandParserService ?? throw new ArgumentNullException(nameof(commandParserService)); // Store injected service
         _deleteTopicService = deleteTopicService; // Store injected delete topic service (optional)
@@ -761,6 +762,8 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
         _iconService = iconService; // Store injected icon service (optional)
         _publishHistoryService = publishHistoryService; // Store injected publish history service (optional)
         _fileAutoCompleteService = fileAutoCompleteService; // Store injected file autocomplete service (optional)
+        _azureTokenProviderFactory = azureTokenProviderFactory
+            ?? (scope => new AzureAccessTokenProvider(scope)); // Real DefaultAzureCredential-backed provider in prod
         _uiScheduler = uiScheduler 
             ?? (Application.Current == null ? Scheduler.Immediate : RxSchedulers.MainThreadScheduler); // Use Immediate in non-Avalonia (plain unit test) context
         _testMode = Application.Current == null
@@ -770,6 +773,18 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
                     || uiScheduler == Scheduler.Immediate; // If ImmediateScheduler is injected, we're definitely in test mode
         _syncContext = SynchronizationContext.Current; // Capture sync context
         Settings = new SettingsViewModel(environmentOverrides); // Instantiate settings with env overrides
+        Settings.HostnameNormalized += (_, args) =>
+        {
+            // Surface user-visible corrections (URL scheme stripped, port
+            // extracted, Event Grid HTTP → MQTT suffix rewritten, etc.) via the
+            // status bar so the user isn't confused by a silently changed field.
+            StatusBarText = args.ToStatusMessage();
+            Log.Information(
+                "Hostname normalized: '{Original}' → '{Cleaned}' (notes: {Notes})",
+                args.Original,
+                args.Cleaned,
+                string.Join("; ", args.Notes));
+        };
         _environmentOverrides = environmentOverrides;
         JsonViewer = new JsonViewerViewModel(); // Instantiate JSON viewer VM
         CopyTextToClipboardInteraction = new Interaction<string, Unit>(); // Initialize the interaction
@@ -1049,6 +1064,7 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
             AuthMode = Settings.Into().AuthMode,
             UseTls = Settings.UseTls,
             SubscriptionQoS = Settings.SubscriptionQoS,
+            SubscriptionTopic = Settings.SubscriptionTopic,
             Transport = Settings.SelectedTransport,
             WebSocketPath = Settings.WebSocketPath
         });
@@ -2462,11 +2478,74 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
     private async Task ConnectAsync()
     {
         Log.Information("Connect command executed.");
-        
+
         // Clear any previous error message before starting new connection
         ConnectionStatusMessage = null;
         this.RaisePropertyChanged(nameof(HasConnectionError));
-        
+
+        // Coherence check: refuse to connect when the hostname obviously targets
+        // Azure Event Grid but the auth mode isn't Azure. Otherwise the client
+        // would fire an anonymous / userpass CONNECT that Event Grid rejects and
+        // then loop through reconnects with an opaque error.
+        var hostIsEventGrid = IsAzureEventGridHost(Settings.Hostname);
+        var modeIsAzure = Settings.SelectedAuthMode == SettingsViewModel.AuthModeSelection.Azure;
+
+        if (hostIsEventGrid && !modeIsAzure)
+        {
+            var msg =
+                $"Cannot connect: hostname '{Settings.Hostname}' looks like Azure Event Grid, "
+                + $"but auth mode is '{Settings.SelectedAuthMode}'. Azure Event Grid rejects anonymous / "
+                + "username-password / K8S-SAT CONNECTs. Run ':setauthmode azure' first, then retry ':connect'.";
+            StatusBarText = msg;
+            ConnectionStatusMessage = msg;
+            this.RaisePropertyChanged(nameof(HasConnectionError));
+            Log.Warning(
+                "Refusing connect: Event Grid hostname '{Host}' with non-Azure auth mode {Mode}.",
+                Settings.Hostname,
+                Settings.SelectedAuthMode);
+            return;
+        }
+
+        if (modeIsAzure && !hostIsEventGrid)
+        {
+            // Soft warning only — the mock broker on localhost is a legitimate
+            // Azure-mode target that isn't an Event Grid FQDN, so don't block.
+            StatusBarText =
+                $"Note: Azure auth mode is selected but hostname '{Settings.Hostname}' isn't an Event Grid "
+                + "topic-space endpoint. Continuing — if this isn't intentional, set the hostname to "
+                + "'<namespace>.<region>-1.ts.eventgrid.azure.net'.";
+            Log.Information(
+                "Azure auth mode with non-Event-Grid hostname '{Host}'. Proceeding.",
+                Settings.Hostname);
+        }
+
+        // Azure Event Grid rejects OAUTH2-JWT CONNECT when the Client ID
+        // doesn't map to a client resource / attribute rule on the namespace.
+        // Surface an actionable warning without blocking (some attribute-based
+        // setups do allow auto-generated Client IDs).
+        if (modeIsAzure && string.IsNullOrWhiteSpace(Settings.ClientId))
+        {
+            StatusBarText =
+                "Warning: Azure Event Grid usually requires the MQTT Client ID to match a registered client "
+                + "(or a client-authentication-name attribute) on the namespace. An empty/auto-generated Client ID "
+                + "will typically be rejected with NotAuthorized. Run ':azurewhoami' to see the identity that will "
+                + "be used, then ':setclientid <name>' to set the Client ID. Attempting connection anyway...";
+            Log.Warning("Connecting to Azure Event Grid with empty Client ID — connection is likely to fail.");
+        }
+
+        // Azure Event Grid always rejects SUBSCRIBE to '#'. Warn (soft) so the
+        // user isn't surprised when the subscription bounces after a successful
+        // CONNECT; don't block, because the user might explicitly want the
+        // CONNECT to succeed to verify auth even if SUBSCRIBE won't.
+        if (modeIsAzure && Settings.SubscriptionTopic == "#")
+        {
+            StatusBarText =
+                "Warning: Subscription filter is '#' but Azure Event Grid rejects wildcard subscriptions outside "
+                + "your Topic Space. Change it with ':setsubscription <filter>' (e.g. 'sensors/#') that matches "
+                + "your Topic Space template. Attempting connection anyway...";
+            Log.Warning("Connecting to Azure Event Grid with default '#' subscription filter — SUBSCRIBE will be rejected.");
+        }
+
         // Rebuild connection settings from ViewModel just before connecting
         var connectionSettings = new MqttConnectionSettings
         {
@@ -2481,6 +2560,7 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             AuthMode = Settings.Into().AuthMode,
             UseTls = Settings.UseTls,
             SubscriptionQoS = Settings.SubscriptionQoS,
+            SubscriptionTopic = Settings.SubscriptionTopic,
             Transport = Settings.SelectedTransport,
             WebSocketPath = Settings.WebSocketPath
         };
@@ -2528,6 +2608,86 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         SelectedNode = null;           // Deselect any active node
         Log.Information("Message history and topic tree cleared.");
         ShowStatus("Message history and topic tree cleared.");
+    }
+
+    /// <summary>
+    /// Fetches an Azure access token via <c>DefaultAzureCredential</c>, decodes
+    /// the JWT, and surfaces the caller-identifying claims to the status bar so
+    /// users can register a matching Event Grid Client resource. Best-effort:
+    /// swallows credential errors and reports them via the status bar.
+    /// </summary>
+    private async Task ExecuteAzureWhoAmIAsync()
+    {
+        try
+        {
+            var scope = (Settings.AuthenticationScope is { Length: > 0 } s)
+                ? s
+                : AzureAuthenticationMode.DefaultScope;
+
+            StatusBarText = $"Requesting Azure access token for scope '{scope}'...";
+
+            var provider = _azureTokenProviderFactory(scope);
+            var token = await provider.GetTokenAsync().ConfigureAwait(false);
+
+            var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token.Token);
+
+            static string? Claim(System.IdentityModel.Tokens.Jwt.JwtSecurityToken t, string name) =>
+                t.Claims.FirstOrDefault(c => c.Type == name)?.Value;
+
+            var oid = Claim(jwt, "oid");
+            var upn = Claim(jwt, "upn") ?? Claim(jwt, "preferred_username") ?? Claim(jwt, "unique_name");
+            var name = Claim(jwt, "name");
+            var appId = Claim(jwt, "appid") ?? Claim(jwt, "azp");
+            var tid = Claim(jwt, "tid");
+            var idType = Claim(jwt, "idtyp"); // "user" or "app"
+
+            var parts = new List<string>();
+            if (!string.IsNullOrEmpty(upn)) parts.Add($"upn={upn}");
+            if (!string.IsNullOrEmpty(name)) parts.Add($"name={name}");
+            if (!string.IsNullOrEmpty(oid)) parts.Add($"oid={oid}");
+            if (!string.IsNullOrEmpty(appId)) parts.Add($"appid={appId}");
+            if (!string.IsNullOrEmpty(tid)) parts.Add($"tenant={tid}");
+            if (!string.IsNullOrEmpty(idType)) parts.Add($"type={idType}");
+
+            var summary = parts.Count == 0
+                ? "Signed in, but the returned token has no identifying claims."
+                : "Signed in as " + string.Join(", ", parts);
+
+            var suggestedName = oid ?? upn ?? appId;
+            var hint = suggestedName is null
+                ? " Register an Event Grid Client whose authenticationName matches one of these values, then set MQTT Client ID (:setclientid <name>) to that client's name."
+                : $" '{suggestedName}' copied to clipboard — use it as the Client authenticationName on your Event Grid namespace. Then run :setclientid <client-name>.";
+
+            StatusBarText = summary + "." + hint;
+            Log.Information(
+                "Azure whoami: token acquired (expires {Expiry:O}). Claims: {Summary}",
+                token.ExpiresOn,
+                summary);
+
+            // Push the most useful identifier to the clipboard so the user can
+            // paste it straight into `az eventgrid namespace client create
+            // --authentication-name <value>` (or the portal). Best-effort; if
+            // there's no clipboard handler registered we simply log and move on.
+            if (suggestedName is not null)
+            {
+                try
+                {
+                    await CopyTextToClipboardInteraction.Handle(suggestedName);
+                    Log.Information("Copied Azure identity '{Suggested}' to clipboard.", suggestedName);
+                }
+                catch (Exception clipEx)
+                {
+                    Log.Warning(clipEx, "Failed to copy Azure identity to clipboard.");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusBarText =
+                $"Azure whoami failed: {ex.Message}. Try 'az login' or ensure AZURE_CLIENT_ID/TENANT_ID/CLIENT_SECRET are set.";
+            Log.Warning(ex, "Azure whoami failed.");
+        }
     }
 
     private async Task ExecuteDeleteTopicAsync()
@@ -3068,9 +3228,31 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                         else if (mode == "azure")
                         {
                             this.Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+
+                            // Nudge unrealistic timing values toward Azure Event Grid
+                            // defaults. The broker enforces a minimum keep-alive
+                            // (usually ≥30s) and rejects extremely short session
+                            // expiries with CleanSession=true.
+                            if (this.Settings.KeepAliveIntervalSeconds < 30)
+                            {
+                                this.Settings.KeepAliveIntervalSeconds = 30;
+                            }
+                            if (this.Settings.SessionExpiryIntervalSeconds is null or < 300)
+                            {
+                                this.Settings.SessionExpiryIntervalSeconds = 3600;
+                            }
+
+                            var wildcardHint = this.Settings.SubscriptionTopic == "#"
+                                ? " Also change ':setsubscription <filter>' — Azure Event Grid always rejects '#'; use a filter that matches your Topic Space template (e.g. 'sensors/#')."
+                                : string.Empty;
+
                             StatusBarText =
                                 "Authentication mode set to Azure (OAUTH2-JWT via DefaultAzureCredential). "
-                                + "Port 8883, TLS, and TCP transport have been enabled. Settings will be saved.";
+                                + "Port 8883, TLS, TCP transport, and safe Keep Alive / Session Expiry values enabled. "
+                                + "Set the MQTT Client ID (:setclientid <name>) to match a registered Client resource on your Event Grid namespace. "
+                                + "Run :azurewhoami to see the identity that will be used for token acquisition."
+                                + wildcardHint
+                                + " Settings will be saved.";
                             Log.Information("Authentication mode set to Azure via command.");
                         }
                         else
@@ -3107,9 +3289,31 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                 case CommandType.SetAuthMethod:
                     if (command.Arguments.Count == 1)
                     {
-                        this.Settings.AuthenticationMethod = command.Arguments[0];
-                        StatusBarText = $"Authentication method set to '{command.Arguments[0]}'. Settings will be saved.";
-                        Log.Information("Authentication method set via command: {Method}", command.Arguments[0]);
+                        var methodArg = command.Arguments[0];
+                        // Guard against a very common autocomplete slip: :setauthmethod
+                        // and :setauthmode share a prefix, and the palette sorts
+                        // alphabetically so 'method' appears above 'mode'. If the
+                        // user passes a known auth-mode name here, redirect them
+                        // rather than silently writing to the (unused) enhanced-auth
+                        // method field.
+                        var lowered = methodArg.ToLowerInvariant();
+                        if (lowered is "anonymous" or "userpass" or "enhanced" or "azure")
+                        {
+                            StatusBarText =
+                                $"'{methodArg}' is an authentication *mode*, not a *method*. "
+                                + $"Did you mean ':setauthmode {lowered}'? "
+                                + "(:setauthmethod sets the enhanced-auth method like 'SCRAM-SHA-1' or 'K8S-SAT'.)";
+                            Log.Warning(
+                                "Rejected :setauthmethod {Arg} — argument matches an auth mode name; user likely meant :setauthmode.",
+                                methodArg);
+                        }
+                        else
+                        {
+                            this.Settings.AuthenticationMethod = methodArg;
+                            StatusBarText =
+                                $"Enhanced-auth method set to '{methodArg}' (applied when auth mode is Enhanced). Settings will be saved.";
+                            Log.Information("Enhanced-auth method set via command: {Method}", methodArg);
+                        }
                     }
                     else
                     {
@@ -3142,6 +3346,39 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                         StatusBarText = "Error: :setauthscope requires exactly one argument <scope>.";
                         Log.Warning("Invalid arguments for SetAuthScope command.");
                     }
+                    break;
+                case CommandType.SetClientId:
+                    if (command.Arguments.Count == 0)
+                    {
+                        this.Settings.ClientId = null;
+                        StatusBarText = "MQTT Client ID cleared (broker will assign one). Settings will be saved.";
+                        Log.Information("MQTT Client ID cleared via command.");
+                    }
+                    else
+                    {
+                        var newClientId = command.Arguments[0];
+                        this.Settings.ClientId = newClientId;
+                        StatusBarText = $"MQTT Client ID set to '{newClientId}'. Settings will be saved.";
+                        Log.Information("MQTT Client ID set via command: {ClientId}", newClientId);
+                    }
+                    break;
+                case CommandType.SetSubscriptionTopic:
+                    if (command.Arguments.Count == 0)
+                    {
+                        this.Settings.SubscriptionTopic = "#";
+                        StatusBarText = "Subscription topic reset to '#'. Reconnect for the new subscription to take effect.";
+                        Log.Information("Subscription topic reset to '#' via command.");
+                    }
+                    else
+                    {
+                        var newFilter = command.Arguments[0];
+                        this.Settings.SubscriptionTopic = newFilter;
+                        StatusBarText = $"Subscription topic set to '{newFilter}'. Reconnect for the new subscription to take effect.";
+                        Log.Information("Subscription topic set via command: {Filter}", newFilter);
+                    }
+                    break;
+                case CommandType.AzureWhoAmI:
+                    _ = ExecuteAzureWhoAmIAsync();
                     break;
                 case CommandType.SetUseTls:
                     if (command.Arguments.Count == 1)
@@ -3203,6 +3440,9 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         { "setauthmethod", (":setauthmethod <method>", "Sets the authentication method for enhanced authentication (e.g., SCRAM-SHA-1, K8S-SAT).") },
         { "setauthdata", (":setauthdata <data>", "Sets the authentication data for enhanced authentication (method-specific data).") },
         { "setauthscope", (":setauthscope <scope>", "Sets the OAuth scope requested when Azure authentication mode is active. Defaults to https://eventgrid.azure.net/.default.") },
+        { "setclientid", (":setclientid [<client-id>]", "Sets the MQTT Client ID. Required for Azure Event Grid to match a registered Client resource on the namespace. Omit the argument to clear.") },
+        { "setsubscription", (":setsubscription [<topic-filter>]", "Sets the MQTT topic filter used for the initial subscription. Defaults to '#' (all topics); Azure Event Grid requires a filter matching your Topic Space template (e.g. 'sensors/#'). Reconnect after changing.") },
+        { "azurewhoami", (":azurewhoami", "Prints the identity (upn, oid, name, appid) that DefaultAzureCredential would use for Azure Event Grid token acquisition. Useful for choosing the correct Event Grid Client authenticationName.") },
         { "setusetls", (":setusetls <true|false>", "Sets whether to use TLS for MQTT connections. true = enable TLS, false = disable TLS.") },
         { "deletetopic", (":deletetopic [topic-pattern] [--confirm]", "Deletes retained messages from a topic and its subtopics by publishing empty retained messages. Uses selected topic if no pattern specified.") },
         { "gotoresponse", (":gotoresponse", "Navigates to the response message for the currently selected MQTT v5 request message.") },
@@ -3400,7 +3640,10 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
 
     /// <summary>
     /// Returns true when <paramref name="host"/> looks like an Azure Event Grid namespace
-    /// MQTT broker (matches the well-known suffix <c>.ts.eventgrid.azure.net</c>).
+    /// endpoint — either the MQTT topic-space FQDN (<c>*.ts.eventgrid.azure.net</c>)
+    /// or the HTTP data-plane URL (<c>*.eventgrid.azure.net</c>). The latter is
+    /// accepted so that pasted Data Plane URLs still trigger the Azure auto-
+    /// config path; the hostname normalizer rewrites them to the MQTT form.
     /// </summary>
     internal static bool IsAzureEventGridHost(string? host)
     {
@@ -3408,7 +3651,8 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         {
             return false;
         }
-        return host.EndsWith(".ts.eventgrid.azure.net", StringComparison.OrdinalIgnoreCase);
+        return host.EndsWith(".ts.eventgrid.azure.net", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".eventgrid.azure.net", StringComparison.OrdinalIgnoreCase);
     }
 
     private void Export(ParsedCommand command)

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -23,6 +23,7 @@ using System.Linq; // For .Select
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.AnonymousAuthenticationMode))] // Added for AuthMode
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.UsernamePasswordAuthenticationMode))] // Added for AuthMode
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.EnhancedAuthenticationMode))] // Added for AuthMode
+[JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.AzureAuthenticationMode))] // Added for Azure Event Grid auth
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Exporter.ExportTypes))]
 [JsonSerializable(typeof(Nullable<CrowsNestMqtt.BusinessLogic.Exporter.ExportTypes>))]
 [JsonSerializable(typeof(CrowsNestMqtt.BusinessLogic.Configuration.TransportProtocol))]
@@ -46,7 +47,8 @@ public class SettingsViewModel : ReactiveObject
     {
         Anonymous,
         UsernamePassword,
-        Enhanced
+        Enhanced,
+        Azure
     }
 
     internal static string _settingsFilePath = Path.Combine(
@@ -168,11 +170,13 @@ public class SettingsViewModel : ReactiveObject
             this.WhenAnyValue(x => x.SubscriptionQoS),
             (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
 
-        // Observable for transport-related property changes
+        // Observable for transport-related property changes (and Azure scope, kept here
+        // because the simplePropertiesChanged CombineLatest already hit its 15-arg cap)
         var transportPropertiesChanged = Observable.CombineLatest(
             this.WhenAnyValue(x => x.SelectedTransport),
             this.WhenAnyValue(x => x.WebSocketPath),
-            (_, _) => Unit.Default);
+            this.WhenAnyValue(x => x.AuthenticationScope),
+            (_, _, _) => Unit.Default);
 
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
@@ -229,7 +233,8 @@ public class SettingsViewModel : ReactiveObject
             {
                 AuthModeSelection.Anonymous,
                 AuthModeSelection.UsernamePassword,
-                AuthModeSelection.Enhanced
+                AuthModeSelection.Enhanced,
+                AuthModeSelection.Azure
             });
 
         _availableTransports = new ReadOnlyObservableCollection<TransportProtocol>(
@@ -260,6 +265,19 @@ public class SettingsViewModel : ReactiveObject
             this.RaiseAndSetIfChanged(ref _selectedAuthMode, value);
             this.RaisePropertyChanged(nameof(IsUsernamePasswordSelected));
             this.RaisePropertyChanged(nameof(IsEnhancedAuthSelected));
+            this.RaisePropertyChanged(nameof(IsAzureAuthSelected));
+
+            // Azure Event Grid namespaces require TLS on TCP port 8883 with MQTT v5.
+            // Auto-apply those values so a user picking Azure interactively doesn't
+            // need to remember the prerequisites. Skipped during LoadSettings /
+            // From / ApplyEnvironmentOverrides so file- or env-supplied Port and
+            // Transport values aren't clobbered.
+            if (value == AuthModeSelection.Azure && !_isLoading)
+            {
+                UseTls = true;
+                Port = 8883;
+                SelectedTransport = TransportProtocol.Tcp;
+            }
         }
     }
 
@@ -267,6 +285,12 @@ public class SettingsViewModel : ReactiveObject
     public bool IsUsernamePasswordSelected => SelectedAuthMode == AuthModeSelection.UsernamePassword;
 
     public bool IsEnhancedAuthSelected => SelectedAuthMode == AuthModeSelection.Enhanced;
+
+    /// <summary>
+    /// Whether Azure (DefaultAzureCredential / OAUTH2-JWT) auth mode is currently selected.
+    /// Used by UI bindings to show Azure-specific configuration rows.
+    /// </summary>
+    public bool IsAzureAuthSelected => SelectedAuthMode == AuthModeSelection.Azure;
 
     private string _authUsername = string.Empty;
     public string AuthUsername
@@ -294,6 +318,17 @@ public class SettingsViewModel : ReactiveObject
     {
         get => _authenticationData;
         set => this.RaiseAndSetIfChanged(ref _authenticationData, value);
+    }
+
+    private string? _authenticationScope;
+    /// <summary>
+    /// OAuth scope used when Azure authentication mode is active. When null/empty, the
+    /// engine falls back to <see cref="AzureAuthenticationMode.DefaultScope"/>.
+    /// </summary>
+    public string? AuthenticationScope
+    {
+        get => _authenticationScope;
+        set => this.RaiseAndSetIfChanged(ref _authenticationScope, value);
     }
 
     private string? _clientId; // Null or empty means MQTTnet generates one
@@ -361,6 +396,10 @@ public class SettingsViewModel : ReactiveObject
         {
             authModeSetting = new EnhancedAuthenticationMode(AuthenticationMethod, AuthenticationData);
         }
+        else if (SelectedAuthMode == AuthModeSelection.Azure)
+        {
+            authModeSetting = new AzureAuthenticationMode(AuthenticationScope);
+        }
         else
         {
             authModeSetting = new AnonymousAuthenticationMode();
@@ -388,122 +427,173 @@ public class SettingsViewModel : ReactiveObject
 
     public void From(SettingsData settingsData)
     {
-        Hostname = settingsData.Hostname;
-        Port = settingsData.Port;
-        ClientId = settingsData.ClientId;
-        KeepAliveIntervalSeconds = settingsData.KeepAliveIntervalSeconds;
-        CleanSession = settingsData.CleanSession;
-        SessionExpiryIntervalSeconds = settingsData.SessionExpiryIntervalSeconds;
-        ExportFormat = settingsData.ExportFormat;
-        ExportPath = settingsData.ExportPath;
-        UseTls = settingsData.UseTls;
-        SubscriptionQoS = settingsData.SubscriptionQoS;
-        SelectedTransport = settingsData.Transport;
-        WebSocketPath = settingsData.WebSocketPath;
-        TopicSpecificLimits.Clear();
-        
-        // Ensure we always have the default '#' limit
-        bool hasDefaultLimit = false;
-        if (settingsData.TopicSpecificBufferLimits != null)
+        // Suppress the Azure auth-mode setter's auto-config here — settingsData
+        // may legitimately carry a non-default Port/Transport (e.g. from a
+        // persisted Aspire-provisioned configuration) that must not be
+        // overwritten with the Event Grid 8883/Tcp defaults.
+        var wasLoading = _isLoading;
+        _isLoading = true;
+        try
         {
-            foreach (var limitModel in settingsData.TopicSpecificBufferLimits)
+            Hostname = settingsData.Hostname;
+            Port = settingsData.Port;
+            ClientId = settingsData.ClientId;
+            KeepAliveIntervalSeconds = settingsData.KeepAliveIntervalSeconds;
+            CleanSession = settingsData.CleanSession;
+            SessionExpiryIntervalSeconds = settingsData.SessionExpiryIntervalSeconds;
+            ExportFormat = settingsData.ExportFormat;
+            ExportPath = settingsData.ExportPath;
+            UseTls = settingsData.UseTls;
+            SubscriptionQoS = settingsData.SubscriptionQoS;
+            SelectedTransport = settingsData.Transport;
+            WebSocketPath = settingsData.WebSocketPath;
+            TopicSpecificLimits.Clear();
+
+            // Ensure we always have the default '#' limit
+            bool hasDefaultLimit = false;
+            if (settingsData.TopicSpecificBufferLimits != null)
             {
-                TopicSpecificLimits.Add(new TopicBufferLimitViewModel(limitModel));
-                if (limitModel.TopicFilter == "#")
+                foreach (var limitModel in settingsData.TopicSpecificBufferLimits)
                 {
-                    hasDefaultLimit = true;
+                    TopicSpecificLimits.Add(new TopicBufferLimitViewModel(limitModel));
+                    if (limitModel.TopicFilter == "#")
+                    {
+                        hasDefaultLimit = true;
+                    }
                 }
             }
-        }
-        
-        // Add default '#' limit if not present (1MB = 1024*1024 bytes)
-        if (!hasDefaultLimit)
-        {
-            TopicSpecificLimits.Insert(0, new TopicBufferLimitViewModel(new TopicBufferLimit("#", 1024 * 1024)));
-        }
 
-        // Handle AuthMode and credentials
-        if (settingsData.AuthMode is EnhancedAuthenticationMode enhancedAuth)
-        {
-            SelectedAuthMode = AuthModeSelection.Enhanced;
-            AuthenticationMethod = enhancedAuth.AuthenticationMethod;
-            AuthenticationData = enhancedAuth.AuthenticationData;
-            AuthUsername = string.Empty;
-            AuthPassword = string.Empty;
-        }
-        else if (settingsData.AuthMode is UsernamePasswordAuthenticationMode userPassAuth)
-        {
-            SelectedAuthMode = AuthModeSelection.UsernamePassword;
-            AuthUsername = userPassAuth.Username ?? string.Empty;
-            AuthPassword = userPassAuth.Password ?? string.Empty;
-            AuthenticationMethod = null;
-            AuthenticationData = null;
-        }
-        else // Covers AnonymousAuthenticationMode and null (for older settings if AuthMode wasn't present)
-        {
-            SelectedAuthMode = AuthModeSelection.Anonymous;
-            AuthUsername = string.Empty;
-            AuthPassword = string.Empty;
-            AuthenticationMethod = null;
-            AuthenticationData = null;
-        }
-    }
+            // Add default '#' limit if not present (1MB = 1024*1024 bytes)
+            if (!hasDefaultLimit)
+            {
+                TopicSpecificLimits.Insert(0, new TopicBufferLimitViewModel(new TopicBufferLimit("#", 1024 * 1024)));
+            }
 
-    /// <summary>
-    /// Applies environment variable overrides on top of file-based settings.
-    /// Only non-null properties in the overrides are applied.
-    /// </summary>
-    internal void ApplyEnvironmentOverrides(EnvironmentSettingsOverrides overrides)
-    {
-        if (overrides.Hostname != null) Hostname = overrides.Hostname;
-        if (overrides.Port.HasValue) Port = overrides.Port.Value;
-        if (overrides.ClientId != null) ClientId = overrides.ClientId;
-        if (overrides.KeepAliveIntervalSeconds.HasValue) KeepAliveIntervalSeconds = overrides.KeepAliveIntervalSeconds.Value;
-        if (overrides.CleanSession.HasValue) CleanSession = overrides.CleanSession.Value;
-        if (overrides.SessionExpiryIntervalSeconds.HasValue) SessionExpiryIntervalSeconds = overrides.SessionExpiryIntervalSeconds.Value;
-        if (overrides.UseTls.HasValue) UseTls = overrides.UseTls.Value;
-        if (overrides.SubscriptionQoS.HasValue) SubscriptionQoS = overrides.SubscriptionQoS.Value;
-        if (overrides.ExportFormat.HasValue) ExportFormat = overrides.ExportFormat.Value;
-        if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
-        if (overrides.Transport.HasValue) SelectedTransport = overrides.Transport.Value;
-        if (overrides.WebSocketPath != null) WebSocketPath = overrides.WebSocketPath;
-
-        if (overrides.AuthMode != null)
-        {
-            if (overrides.AuthMode is EnhancedAuthenticationMode enhanced)
+            // Handle AuthMode and credentials
+            if (settingsData.AuthMode is EnhancedAuthenticationMode enhancedAuth)
             {
                 SelectedAuthMode = AuthModeSelection.Enhanced;
-                AuthenticationMethod = enhanced.AuthenticationMethod;
-                AuthenticationData = enhanced.AuthenticationData;
+                AuthenticationMethod = enhancedAuth.AuthenticationMethod;
+                AuthenticationData = enhancedAuth.AuthenticationData;
                 AuthUsername = string.Empty;
                 AuthPassword = string.Empty;
+                AuthenticationScope = null;
             }
-            else if (overrides.AuthMode is UsernamePasswordAuthenticationMode userPass)
+            else if (settingsData.AuthMode is UsernamePasswordAuthenticationMode userPassAuth)
             {
                 SelectedAuthMode = AuthModeSelection.UsernamePassword;
-                AuthUsername = userPass.Username;
-                AuthPassword = userPass.Password;
+                AuthUsername = userPassAuth.Username ?? string.Empty;
+                AuthPassword = userPassAuth.Password ?? string.Empty;
+                AuthenticationMethod = null;
+                AuthenticationData = null;
+                AuthenticationScope = null;
+            }
+            else if (settingsData.AuthMode is AzureAuthenticationMode azureAuth)
+            {
+                AuthenticationScope = azureAuth.Scope;
+                SelectedAuthMode = AuthModeSelection.Azure;
+                AuthUsername = string.Empty;
+                AuthPassword = string.Empty;
                 AuthenticationMethod = null;
                 AuthenticationData = null;
             }
-            else
+            else // Covers AnonymousAuthenticationMode and null (for older settings if AuthMode wasn't present)
             {
                 SelectedAuthMode = AuthModeSelection.Anonymous;
                 AuthUsername = string.Empty;
                 AuthPassword = string.Empty;
                 AuthenticationMethod = null;
                 AuthenticationData = null;
+                AuthenticationScope = null;
             }
         }
-
-        if (overrides.TopicSpecificBufferLimits != null)
+        finally
         {
-            TopicSpecificLimits.Clear();
-            foreach (var limit in overrides.TopicSpecificBufferLimits)
+            _isLoading = wasLoading;
+        }
+    }
+
+    /// <summary>
+    /// Applies environment variable overrides on top of file-based settings.
+    /// Only non-null properties in the overrides are applied. Any Azure
+    /// auto-configuration triggered by <see cref="SelectedAuthMode"/> is
+    /// suppressed for the duration of this call so an explicit
+    /// <c>CROWSNEST__PORT</c>/<c>CROWSNEST__USE_TLS</c>/<c>CROWSNEST__TRANSPORT</c>
+    /// override is preserved rather than being reset to the Event Grid defaults
+    /// of 8883/true/Tcp.
+    /// </summary>
+    internal void ApplyEnvironmentOverrides(EnvironmentSettingsOverrides overrides)
+    {
+        var wasLoading = _isLoading;
+        _isLoading = true;
+        try
+        {
+            if (overrides.Hostname != null) Hostname = overrides.Hostname;
+            if (overrides.Port.HasValue) Port = overrides.Port.Value;
+            if (overrides.ClientId != null) ClientId = overrides.ClientId;
+            if (overrides.KeepAliveIntervalSeconds.HasValue) KeepAliveIntervalSeconds = overrides.KeepAliveIntervalSeconds.Value;
+            if (overrides.CleanSession.HasValue) CleanSession = overrides.CleanSession.Value;
+            if (overrides.SessionExpiryIntervalSeconds.HasValue) SessionExpiryIntervalSeconds = overrides.SessionExpiryIntervalSeconds.Value;
+            if (overrides.UseTls.HasValue) UseTls = overrides.UseTls.Value;
+            if (overrides.SubscriptionQoS.HasValue) SubscriptionQoS = overrides.SubscriptionQoS.Value;
+            if (overrides.ExportFormat.HasValue) ExportFormat = overrides.ExportFormat.Value;
+            if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
+            if (overrides.Transport.HasValue) SelectedTransport = overrides.Transport.Value;
+            if (overrides.WebSocketPath != null) WebSocketPath = overrides.WebSocketPath;
+
+            if (overrides.AuthMode != null)
             {
-                TopicSpecificLimits.Add(new TopicBufferLimitViewModel(limit));
+                if (overrides.AuthMode is EnhancedAuthenticationMode enhanced)
+                {
+                    SelectedAuthMode = AuthModeSelection.Enhanced;
+                    AuthenticationMethod = enhanced.AuthenticationMethod;
+                    AuthenticationData = enhanced.AuthenticationData;
+                    AuthUsername = string.Empty;
+                    AuthPassword = string.Empty;
+                    AuthenticationScope = null;
+                }
+                else if (overrides.AuthMode is UsernamePasswordAuthenticationMode userPass)
+                {
+                    SelectedAuthMode = AuthModeSelection.UsernamePassword;
+                    AuthUsername = userPass.Username;
+                    AuthPassword = userPass.Password;
+                    AuthenticationMethod = null;
+                    AuthenticationData = null;
+                    AuthenticationScope = null;
+                }
+                else if (overrides.AuthMode is AzureAuthenticationMode azure)
+                {
+                    AuthenticationScope = azure.Scope;
+                    SelectedAuthMode = AuthModeSelection.Azure;
+                    AuthUsername = string.Empty;
+                    AuthPassword = string.Empty;
+                    AuthenticationMethod = null;
+                    AuthenticationData = null;
+                }
+                else
+                {
+                    SelectedAuthMode = AuthModeSelection.Anonymous;
+                    AuthUsername = string.Empty;
+                    AuthPassword = string.Empty;
+                    AuthenticationMethod = null;
+                    AuthenticationData = null;
+                    AuthenticationScope = null;
+                }
             }
-            EnsureDefaultTopicLimit();
+
+            if (overrides.TopicSpecificBufferLimits != null)
+            {
+                TopicSpecificLimits.Clear();
+                foreach (var limit in overrides.TopicSpecificBufferLimits)
+                {
+                    TopicSpecificLimits.Add(new TopicBufferLimitViewModel(limit));
+                }
+                EnsureDefaultTopicLimit();
+            }
+        }
+        finally
+        {
+            _isLoading = wasLoading;
         }
     }
 

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,7 @@ namespace CrowsNestMqtt.UI.ViewModels;
 
 using CrowsNestMqtt.BusinessLogic.Exporter;
 using CrowsNestMqtt.BusinessLogic.Configuration;
+using CrowsNestMqtt.BusinessLogic.Services;
 using ReactiveUI;
 using CrowsNestMqtt.Utils; // For AppLogger
 using System;
@@ -123,6 +124,21 @@ public class SettingsViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _subscriptionQoS, Math.Clamp(value, 0, 2));
     }
 
+    private string _subscriptionTopic = "#";
+    /// <summary>
+    /// MQTT topic filter used for the initial subscription. Defaults to <c>#</c>
+    /// (all topics), which works for permissive brokers like EMQX/Mosquitto.
+    /// Azure Event Grid namespaces reject <c>#</c> — set this to a filter that
+    /// matches your Topic Space template (e.g. <c>sensors/#</c>).
+    /// </summary>
+    public string SubscriptionTopic
+    {
+        get => _subscriptionTopic;
+        set => this.RaiseAndSetIfChanged(
+            ref _subscriptionTopic,
+            string.IsNullOrWhiteSpace(value) ? "#" : value);
+    }
+
     public SettingsViewModel(EnvironmentSettingsOverrides? environmentOverrides = null)
     {
         ExportPath = _exportFolderPath; // Set default before loading
@@ -170,13 +186,15 @@ public class SettingsViewModel : ReactiveObject
             this.WhenAnyValue(x => x.SubscriptionQoS),
             (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default);
 
-        // Observable for transport-related property changes (and Azure scope, kept here
-        // because the simplePropertiesChanged CombineLatest already hit its 15-arg cap)
+        // Observable for transport-related property changes (and Azure scope /
+        // subscription topic, kept here because the simplePropertiesChanged
+        // CombineLatest already hit its 15-arg cap)
         var transportPropertiesChanged = Observable.CombineLatest(
             this.WhenAnyValue(x => x.SelectedTransport),
             this.WhenAnyValue(x => x.WebSocketPath),
             this.WhenAnyValue(x => x.AuthenticationScope),
-            (_, _, _) => Unit.Default);
+            this.WhenAnyValue(x => x.SubscriptionTopic),
+            (_, _, _, _) => Unit.Default);
 
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
@@ -241,11 +259,57 @@ public class SettingsViewModel : ReactiveObject
             new ObservableCollection<TransportProtocol>(Enum.GetValues(typeof(TransportProtocol)).Cast<TransportProtocol>()));
     }
 
+    /// <summary>
+    /// Fired when the hostname setter normalizes user input in a non-trivial
+    /// way (e.g. strips a scheme, extracts a port, rewrites the Event Grid
+    /// suffix). Consumers surface the notes to the user via the status bar.
+    /// The event is not raised during load-from-file / env-override phases.
+    /// </summary>
+    public event EventHandler<HostnameNormalizedEventArgs>? HostnameNormalized;
+
     private string _hostname = "localhost";
     public string Hostname
     {
         get => _hostname;
-        set => this.RaiseAndSetIfChanged(ref _hostname, value);
+        set
+        {
+            // Coerce URL-shaped inputs (https://…/api/events), extract inline
+            // ports, and rewrite the Event Grid HTTP suffix to the MQTT topic-
+            // space suffix. This runs every time the property is assigned —
+            // including when the user types into the textbox — so the value in
+            // the ViewModel (and therefore the bound control) always reflects
+            // what MQTTnet actually needs.
+            var normalized = MqttHostnameNormalizer.Normalize(value);
+
+            var backingChanged = !string.Equals(_hostname, normalized.Hostname, StringComparison.Ordinal);
+            var rawInputDiffered = normalized.WasChanged;
+
+            _hostname = normalized.Hostname;
+
+            // ALWAYS raise PropertyChanged when the raw user input differed from
+            // the normalized result, even if the backing field didn't actually
+            // change (e.g. the user pasted the same URL twice). Otherwise the
+            // bound TextBox keeps displaying the raw input because the two-way
+            // binding never sees a source update to overwrite its local buffer.
+            if (backingChanged || rawInputDiffered)
+            {
+                this.RaisePropertyChanged(nameof(Hostname));
+            }
+
+            if (normalized.Port is int extractedPort)
+            {
+                Port = extractedPort;
+            }
+
+            if (!_isLoading && rawInputDiffered)
+            {
+                HostnameNormalized?.Invoke(this, new HostnameNormalizedEventArgs(
+                    original: value ?? string.Empty,
+                    cleaned: normalized.Hostname,
+                    extractedPort: normalized.Port,
+                    notes: normalized.Notes));
+            }
+        }
     }
 
     private int _port = 1883;
@@ -418,7 +482,8 @@ public class SettingsViewModel : ReactiveObject
             UseTls,
             SubscriptionQoS: SubscriptionQoS,
             Transport: SelectedTransport,
-            WebSocketPath: WebSocketPath
+            WebSocketPath: WebSocketPath,
+            SubscriptionTopic: SubscriptionTopic
         )
         {
             TopicSpecificBufferLimits = topicLimits
@@ -445,6 +510,7 @@ public class SettingsViewModel : ReactiveObject
             ExportPath = settingsData.ExportPath;
             UseTls = settingsData.UseTls;
             SubscriptionQoS = settingsData.SubscriptionQoS;
+            SubscriptionTopic = settingsData.SubscriptionTopic;
             SelectedTransport = settingsData.Transport;
             WebSocketPath = settingsData.WebSocketPath;
             TopicSpecificLimits.Clear();

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -138,28 +138,38 @@
               </PathIcon>
               <TextBlock Text="{Binding IsPaused, StringFormat='Paused: {0}'}" VerticalAlignment="Center" Margin="5,0"/>
               <TextBlock Text="(Filtered)" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="Orange" FontStyle="Italic" IsVisible="{Binding IsTopicFilterActive}"/>
-              <!-- Status Bar Text -->
-              <TextBlock Text="{Binding StatusBarText}" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="Gray" FontStyle="Italic"/>
+              <!-- Status Bar Text (selectable + wrappable so long lines like :azurewhoami can be copied) -->
+              <SelectableTextBlock Text="{Binding StatusBarText}"
+                                   VerticalAlignment="Center"
+                                   Margin="10,0,0,0"
+                                   Foreground="Gray"
+                                   FontStyle="Italic"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="900" />
               <!-- Search Status Indicator (FR-022, FR-023, FR-024) -->
-              <TextBlock Text="{Binding SearchStatusViewModel.StatusText}"
+              <SelectableTextBlock Text="{Binding SearchStatusViewModel.StatusText}"
                          VerticalAlignment="Center"
                          Margin="10,0,0,0"
                          Foreground="DodgerBlue"
                          FontStyle="Italic"
                          IsVisible="{Binding SearchStatusViewModel.IsVisible}" />
               <!-- Connection Status Message (for Connecting/Disconnected with error) -->
-              <TextBlock Text="{Binding ConnectionStatusMessage}" 
-                         VerticalAlignment="Center" 
-                         Margin="10,0,0,0" 
-                         Foreground="OrangeRed" 
+              <SelectableTextBlock Text="{Binding ConnectionStatusMessage}"
+                         VerticalAlignment="Center"
+                         Margin="10,0,0,0"
+                         Foreground="OrangeRed"
                          FontStyle="Italic"
+                         TextWrapping="Wrap"
+                         MaxWidth="900"
                          IsVisible="{Binding IsConnecting}" />
               <!-- Connection Error Message (persists when disconnected due to error) -->
-              <TextBlock Text="{Binding ConnectionStatusMessage}" 
-                         VerticalAlignment="Center" 
-                         Margin="10,0,0,0" 
-                         Foreground="Red" 
+              <SelectableTextBlock Text="{Binding ConnectionStatusMessage}"
+                         VerticalAlignment="Center"
+                         Margin="10,0,0,0"
+                         Foreground="Red"
                          FontWeight="SemiBold"
+                         TextWrapping="Wrap"
+                         MaxWidth="900"
                          IsVisible="{Binding HasConnectionError}" />
              </StackPanel>
 
@@ -441,7 +451,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 25 rows (0-24) for Application Settings (rows 16-17 added for Azure auth) -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 26 rows (0-25); row 23 added for Subscription Topic -->
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -594,8 +604,15 @@
                     <TextBlock Grid.Row="1" Text="Higher QoS preserves message delivery guarantees but reduces throughput" FontSize="10" Margin="0,2,0,0"/>
                 </Grid>
 
+                <!-- Subscription Topic -->
+                <TextBlock Grid.Row="23" Grid.Column="0" Text="Subscription Topic:"/>
+                <StackPanel Grid.Row="23" Grid.Column="1" Orientation="Vertical" Spacing="2">
+                    <TextBox Text="{Binding Settings.SubscriptionTopic, Mode=TwoWay}" PlaceholderText="#"/>
+                    <TextBlock Text="Wildcard '#' works for open brokers (EMQX/Mosquitto). Azure Event Grid requires a filter that matches your Topic Space template (e.g. 'sensors/#' or 'devices/+/telemetry')." FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+
                 <!-- Topic Buffer Limits List -->
-                <ItemsControl Grid.Row="23" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
+                <ItemsControl Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:TopicBufferLimitViewModel}">
                             <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto" Margin="0,2">
@@ -606,9 +623,9 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                
+
                 <!-- Add New Limit Button -->
-                <Button Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                <Button Grid.Row="25" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -441,7 +441,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 23 rows (0-22) for Application Settings -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 25 rows (0-24) for Application Settings (rows 16-17 added for Azure auth) -->
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -559,23 +559,33 @@
                             HorizontalAlignment="Stretch"/>
                 </ScrollViewer>
 
+                <!-- Azure Authentication Header -->
+                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="Azure Event Grid Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
+
+                <!-- Azure OAuth Scope -->
+                <TextBlock Grid.Row="17" Grid.Column="0" Text="OAuth Scope:" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
+                <StackPanel Grid.Row="17" Grid.Column="1" Orientation="Vertical" Spacing="2" IsVisible="{Binding Settings.IsAzureAuthSelected}">
+                    <TextBox Text="{Binding Settings.AuthenticationScope, Mode=TwoWay}" PlaceholderText="https://eventgrid.azure.net/.default"/>
+                    <TextBlock Text="Uses DefaultAzureCredential (env vars → managed identity → VS → az CLI → interactive). Token is refreshed automatically before expiry." FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+
                 <!-- General Settings Header -->
-                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="18" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Export Format -->
-                <TextBlock Grid.Row="17" Grid.Column="0" Text="Export Format:"/>
-                <ComboBox Grid.Row="17" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
+                <TextBlock Grid.Row="19" Grid.Column="0" Text="Export Format:"/>
+                <ComboBox Grid.Row="19" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
 
                 <!-- Export Path -->
-                <TextBlock Grid.Row="18" Grid.Column="0" Text="Export Path:"/>
-                <TextBox Grid.Row="18" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
+                <TextBlock Grid.Row="20" Grid.Column="0" Text="Export Path:"/>
+                <TextBox Grid.Row="20" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
 
                 <!-- Application Settings Header -->
-                <TextBlock Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Subscription QoS -->
-                <TextBlock Grid.Row="20" Grid.Column="0" Text="Subscription QoS:"/>
-                <Grid Grid.Row="20" Grid.Column="1" RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="22" Grid.Column="0" Text="Subscription QoS:"/>
+                <Grid Grid.Row="22" Grid.Column="1" RowDefinitions="Auto,Auto">
                     <ComboBox Grid.Row="0" SelectedIndex="{Binding Settings.SubscriptionQoS, Mode=TwoWay}" MinWidth="120">
                         <ComboBoxItem Content="0 - At Most Once"/>
                         <ComboBoxItem Content="1 - At Least Once (Default)"/>
@@ -585,7 +595,7 @@
                 </Grid>
 
                 <!-- Topic Buffer Limits List -->
-                <ItemsControl Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
+                <ItemsControl Grid.Row="23" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:TopicBufferLimitViewModel}">
                             <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto" Margin="0,2">
@@ -598,7 +608,7 @@
                 </ItemsControl>
                 
                 <!-- Add New Limit Button -->
-                <Button Grid.Row="22" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                <Button Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/src/UI/Views/MainView.axaml.cs
+++ b/src/UI/Views/MainView.axaml.cs
@@ -350,8 +350,12 @@ public partial class MainView : UserControl
             return;
         }
 
-        // Check if shortcuts should be suppressed (e.g., command palette has focus)
-        if (vm.KeyboardNavigationService.ShouldSuppressShortcuts())
+        // Suppress j/k/n shortcuts when any text input has focus. The service's
+        // built-in check only handles the command palette; extend it here so
+        // typing 'k' into the Client ID field (or any other TextBox/NumericUpDown)
+        // reaches the control instead of triggering vim-style navigation.
+        if (vm.KeyboardNavigationService.ShouldSuppressShortcuts()
+            || IsTextInputFocused())
         {
             return;
         }
@@ -390,6 +394,35 @@ public partial class MainView : UserControl
                     }
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the currently-focused Avalonia element is a text-input
+    /// control that should absorb keystrokes rather than trigger vim-style
+    /// navigation. This is what stops <c>k</c> from being swallowed while the
+    /// user types into e.g. the Client ID textbox.
+    /// </summary>
+    private bool IsTextInputFocused()
+    {
+        try
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            var focused = topLevel?.FocusManager?.GetFocusedElement();
+            return focused switch
+            {
+                null => false,
+                TextBox => true,   // covers MaskedTextBox and any derived text boxes
+                AutoCompleteBox => true,
+                NumericUpDown => true,
+                // AvaloniaEdit's TextArea (used by the payload viewer + publish editor)
+                AvaloniaEdit.Editing.TextArea => true,
+                _ => false,
+            };
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/tests/AppHost.Tests/AppHost.Tests.csproj
+++ b/tests/AppHost.Tests/AppHost.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>CrowsNestMqtt.AppHostTests</RootNamespace>
+    <AssemblyName>CrowsNestMqtt.AppHostTests</AssemblyName>
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MQTTnet" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AppHost\AppHost.csproj" />
+    <!-- The tests launch the mock broker as a child process (dotnet <dll>), so
+         we need its output on disk. ReferenceOutputAssembly=false keeps the
+         test assembly clean of the mock's transitive types. -->
+    <ProjectReference Include="..\..\tools\MockAzureEventGridBroker\MockAzureEventGridBroker.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/AppHost.Tests/AzureAuthModeAspireTests.cs
+++ b/tests/AppHost.Tests/AzureAuthModeAspireTests.cs
@@ -1,0 +1,375 @@
+namespace CrowsNestMqtt.AppHostTests;
+
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Sockets;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using MQTTnet;
+using Xunit;
+
+/// <summary>
+/// End-to-end tests that verify Azure Event Grid namespace connectivity by
+/// launching the bundled <c>MockAzureEventGridBroker</c> as a child process and
+/// connecting a real MQTTnet v5 client with <c>OAUTH2-JWT</c> enhanced auth.
+///
+/// The broker is the same one wired into the production AppHost as the fourth
+/// Crow's Nest instance, so a green run here is strong evidence that the Aspire
+/// configuration will succeed too.
+///
+/// The tests intentionally do NOT depend on Docker (EMQX) or a display server —
+/// they only need the mock broker to be buildable and a free TCP port.
+/// </summary>
+public sealed class AzureAuthModeAspireTests : IAsyncLifetime
+{
+    private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
+
+    private Process? _brokerProcess;
+    private string _brokerHost = "127.0.0.1";
+    private int _brokerPort;
+    private readonly List<string> _brokerStdout = new();
+    private readonly List<string> _brokerStderr = new();
+
+    public async ValueTask InitializeAsync()
+    {
+        _brokerPort = GetFreeTcpPort();
+        _brokerProcess = StartMockBroker(_brokerHost, _brokerPort);
+
+        // Wait until the broker accepts TCP connections (i.e. is listening).
+        using var startCts = new CancellationTokenSource(StartTimeout);
+        var ct = startCts.Token;
+        Exception? lastError = null;
+        while (!ct.IsCancellationRequested)
+        {
+            if (_brokerProcess.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"Mock broker exited unexpectedly with code {_brokerProcess.ExitCode} before binding to {_brokerHost}:{_brokerPort}.\n"
+                    + $"stdout:\n{string.Join('\n', _brokerStdout)}\n"
+                    + $"stderr:\n{string.Join('\n', _brokerStderr)}");
+            }
+
+            try
+            {
+                using var tcp = new TcpClient();
+                var connectTask = tcp.ConnectAsync(_brokerHost, _brokerPort);
+                var winner = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromMilliseconds(300), ct));
+                if (winner == connectTask && tcp.Connected)
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+            await Task.Delay(200, ct);
+        }
+
+        throw new TimeoutException(
+            $"Mock broker did not accept connections on {_brokerHost}:{_brokerPort} within {StartTimeout}. Last error: {lastError?.Message ?? "(none)"}\n"
+            + $"stdout:\n{string.Join('\n', _brokerStdout)}\n"
+            + $"stderr:\n{string.Join('\n', _brokerStderr)}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_brokerProcess is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!_brokerProcess.HasExited)
+            {
+                _brokerProcess.Kill(entireProcessTree: true);
+                await _brokerProcess.WaitForExitAsync(new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            _brokerProcess.Dispose();
+            _brokerProcess = null;
+        }
+    }
+
+    [Fact]
+    public async Task MockBroker_AcceptsOauth2JwtConnect_And_LogsAcceptance()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var ct = cts.Token;
+
+        var jwt = BuildDevJwt();
+        var factory = new MqttClientFactory();
+        using var client = factory.CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer(_brokerHost, _brokerPort)
+            .WithTlsOptions(o =>
+            {
+                o.UseTls();
+                o.WithAllowUntrustedCertificates(true);
+                o.WithIgnoreCertificateChainErrors(true);
+                o.WithCertificateValidationHandler(_ => true);
+            })
+            .WithClientId("aspire-test-client")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var connectResult = await client.ConnectAsync(options, ct);
+        Assert.Equal(MqttClientConnectResultCode.Success, connectResult.ResultCode);
+
+        // Assert on the broker's captured stdout so we know the reason for
+        // acceptance was actually the OAUTH2-JWT check (not a fallback).
+        var accepted = await WaitForStdoutAsync(
+            log => log.Contains("Accepted CONNECT (method=OAUTH2-JWT", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(10),
+            ct);
+        Assert.True(
+            accepted,
+            "Mock broker did not log OAUTH2-JWT acceptance. Captured stdout:\n"
+                + string.Join('\n', _brokerStdout));
+
+        await client.DisconnectAsync(new MqttClientDisconnectOptionsBuilder().Build(), ct);
+    }
+
+    [Fact]
+    public async Task MockBroker_RejectsAnonymousConnect_WithBadAuthMethod()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var ct = cts.Token;
+
+        var factory = new MqttClientFactory();
+        using var client = factory.CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer(_brokerHost, _brokerPort)
+            .WithTlsOptions(o =>
+            {
+                o.UseTls();
+                o.WithAllowUntrustedCertificates(true);
+                o.WithIgnoreCertificateChainErrors(true);
+                o.WithCertificateValidationHandler(_ => true);
+            })
+            .WithClientId("aspire-test-client-anon")
+            .Build(); // no enhanced auth
+
+        // The mock broker must reject CONNECT without OAUTH2-JWT. Different
+        // MQTTnet builds surface this as either a broker-side reason code in the
+        // CONNACK or a raw connection failure, so accept both shapes.
+        try
+        {
+            var result = await client.ConnectAsync(options, ct);
+            Assert.NotEqual(MqttClientConnectResultCode.Success, result.ResultCode);
+        }
+        catch (Exception ex) when (ex is MQTTnet.Adapter.MqttConnectingFailedException or MQTTnet.Exceptions.MqttCommunicationException)
+        {
+            // Expected: broker rejected the connection.
+        }
+
+        var rejected = await WaitForStdoutAsync(
+            log => log.Contains("Mock broker rejects CONNECT: expected AuthenticationMethod 'OAUTH2-JWT'", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(10),
+            ct);
+        Assert.True(
+            rejected,
+            "Mock broker did not log the expected rejection reason. Captured stdout:\n"
+                + string.Join('\n', _brokerStdout));
+    }
+
+    [Fact]
+    public async Task MockBroker_AcceptsClientInitiatedReauth()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var ct = cts.Token;
+
+        var jwt = BuildDevJwt();
+        var factory = new MqttClientFactory();
+        using var client = factory.CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer(_brokerHost, _brokerPort)
+            .WithTlsOptions(o =>
+            {
+                o.UseTls();
+                o.WithAllowUntrustedCertificates(true);
+                o.WithIgnoreCertificateChainErrors(true);
+                o.WithCertificateValidationHandler(_ => true);
+            })
+            .WithClientId("aspire-test-client-reauth")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var connectResult = await client.ConnectAsync(options, ct);
+        Assert.Equal(MqttClientConnectResultCode.Success, connectResult.ResultCode);
+
+        // Send a client-initiated AUTH packet with a fresh token — this is the
+        // same wire flow MqttEngine's proactive token refresh timer triggers.
+        var refreshedJwt = BuildDevJwt();
+        await client.SendEnhancedAuthenticationExchangeDataAsync(
+            new MqttEnhancedAuthenticationExchangeData
+            {
+                AuthenticationData = Encoding.UTF8.GetBytes(refreshedJwt),
+                ReasonCode = MQTTnet.Protocol.MqttAuthenticateReasonCode.ReAuthenticate,
+            },
+            ct);
+
+        var reauthLogged = await WaitForStdoutAsync(
+            log => log.Contains("Received AUTH (method=OAUTH2-JWT", StringComparison.Ordinal)
+                && log.Contains("reason=ReAuthenticate", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(10),
+            ct);
+        Assert.True(
+            reauthLogged,
+            "Mock broker did not log the client-initiated AUTH re-authentication. Captured stdout:\n"
+                + string.Join('\n', _brokerStdout));
+
+        await client.DisconnectAsync(new MqttClientDisconnectOptionsBuilder().Build(), ct);
+    }
+
+    private Process StartMockBroker(string host, int port)
+    {
+        var dllPath = LocateMockBrokerDll();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = Path.GetDirectoryName(dllPath)!,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add(dllPath);
+        psi.EnvironmentVariables["MOCK_EG_HOST"] = host;
+        psi.EnvironmentVariables["MOCK_EG_PORT"] = port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        psi.EnvironmentVariables["MOCK_EG_USE_TLS"] = "true";
+        // Ensure ASP.NET Core / dotnet host uses server GC etc. — not strictly
+        // required, but keeps output stable across environments.
+        psi.EnvironmentVariables["DOTNET_ENVIRONMENT"] = "Development";
+
+        var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        process.OutputDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                lock (_brokerStdout)
+                {
+                    _brokerStdout.Add(args.Data);
+                }
+            }
+        };
+        process.ErrorDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                lock (_brokerStderr)
+                {
+                    _brokerStderr.Add(args.Data);
+                }
+            }
+        };
+
+        if (!process.Start())
+        {
+            process.Dispose();
+            throw new InvalidOperationException("Failed to start mock broker process.");
+        }
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        return process;
+    }
+
+    private static string LocateMockBrokerDll()
+    {
+        // Walk up from the test's output directory to the repo root, then into
+        // tools/MockAzureEventGridBroker/bin/{Configuration}/net10.0/.
+        var testDir = AppContext.BaseDirectory;
+        var configName = Path.GetFileName(Path.GetDirectoryName(testDir.TrimEnd(Path.DirectorySeparatorChar))!);
+        // testDir looks like ...\tests\AppHost.Tests\bin\Release\net10.0\
+        var directory = new DirectoryInfo(testDir);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "CrowsNestMQTT.slnx")))
+        {
+            directory = directory.Parent;
+        }
+        if (directory is null)
+        {
+            throw new InvalidOperationException($"Could not locate repository root from {testDir}.");
+        }
+
+        var candidates = new[]
+        {
+            Path.Combine(directory.FullName, "tools", "MockAzureEventGridBroker", "bin", "Release", "net10.0", "CrowsNestMqtt.MockAzureEventGridBroker.dll"),
+            Path.Combine(directory.FullName, "tools", "MockAzureEventGridBroker", "bin", "Debug", "net10.0", "CrowsNestMqtt.MockAzureEventGridBroker.dll"),
+        };
+        foreach (var candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        throw new FileNotFoundException(
+            $"Mock broker DLL not found (config={configName}). Build the solution first. Searched:\n"
+                + string.Join('\n', candidates));
+    }
+
+    private async Task<bool> WaitForStdoutAsync(Func<string, bool> predicate, TimeSpan timeout, CancellationToken outerToken)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        int lastCount = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            outerToken.ThrowIfCancellationRequested();
+            string[] snapshot;
+            lock (_brokerStdout)
+            {
+                snapshot = _brokerStdout.Skip(lastCount).ToArray();
+                lastCount = _brokerStdout.Count;
+            }
+            foreach (var line in snapshot)
+            {
+                if (predicate(line))
+                {
+                    return true;
+                }
+            }
+            await Task.Delay(100, outerToken);
+        }
+        return false;
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static string BuildDevJwt()
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes("test-key-that-is-long-enough-for-hmac-signing");
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim("sub", "aspire-test-user") }),
+            Issuer = "https://sts.local",
+            Audience = "https://eventgrid.azure.net",
+            Expires = DateTime.UtcNow.AddHours(1),
+            NotBefore = DateTime.UtcNow.AddMinutes(-5),
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(key),
+                SecurityAlgorithms.HmacSha256Signature),
+        };
+        return handler.WriteToken(handler.CreateToken(descriptor));
+    }
+}
+

--- a/tests/AppHost.Tests/xunit.runner.json
+++ b/tests/AppHost.Tests/xunit.runner.json
@@ -1,0 +1,11 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1,
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": false,
+  "stopOnFail": false,
+  "longRunningTestSeconds": 120
+}

--- a/tests/MockBroker.Tests/CapturingLogWriter.cs
+++ b/tests/MockBroker.Tests/CapturingLogWriter.cs
@@ -1,0 +1,151 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// Thread-safe in-memory <see cref="TextWriter"/> that captures every line the
+/// broker writes via its injected log sink. Tests use this to observe both the
+/// timestamped <c>[mock-eg-broker]</c> lines and the bare
+/// <c>MOCK_EG_LISTENING_ON=</c> stdout line without polluting real stdout.
+/// </summary>
+internal sealed class CapturingLogWriter : TextWriter
+{
+    private readonly StringBuilder _buffer = new();
+    private readonly List<string> _lines = new();
+    private readonly object _sync = new();
+
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public override IFormatProvider FormatProvider => CultureInfo.InvariantCulture;
+
+    public IReadOnlyList<string> Lines
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _lines.ToArray();
+            }
+        }
+    }
+
+    public override void Write(char value)
+    {
+        lock (_sync)
+        {
+            if (value == '\n')
+            {
+                _lines.Add(_buffer.ToString().TrimEnd('\r'));
+                _buffer.Clear();
+            }
+            else
+            {
+                _buffer.Append(value);
+            }
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+        lock (_sync)
+        {
+            foreach (var ch in value)
+            {
+                if (ch == '\n')
+                {
+                    _lines.Add(_buffer.ToString().TrimEnd('\r'));
+                    _buffer.Clear();
+                }
+                else
+                {
+                    _buffer.Append(ch);
+                }
+            }
+        }
+    }
+
+    public override void WriteLine()
+    {
+        lock (_sync)
+        {
+            _lines.Add(_buffer.ToString());
+            _buffer.Clear();
+        }
+    }
+
+    public override void WriteLine(string? value)
+    {
+        lock (_sync)
+        {
+            if (value is not null)
+            {
+                foreach (var ch in value)
+                {
+                    if (ch == '\n')
+                    {
+                        _lines.Add(_buffer.ToString().TrimEnd('\r'));
+                        _buffer.Clear();
+                    }
+                    else
+                    {
+                        _buffer.Append(ch);
+                    }
+                }
+            }
+            _lines.Add(_buffer.ToString());
+            _buffer.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Waits up to <paramref name="timeout"/> for a captured line matching
+    /// <paramref name="predicate"/>. Returns <c>true</c> if a match was seen
+    /// within the deadline.
+    /// </summary>
+    public async Task<bool> WaitForLineAsync(Func<string, bool> predicate, TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string[] snapshot;
+            lock (_sync)
+            {
+                snapshot = _lines.ToArray();
+            }
+            if (snapshot.Any(predicate))
+            {
+                return true;
+            }
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+        }
+        return false;
+    }
+
+    public string RenderedLog
+    {
+        get
+        {
+            lock (_sync)
+            {
+                var sb = new StringBuilder();
+                foreach (var line in _lines)
+                {
+                    sb.AppendLine(line);
+                }
+                if (_buffer.Length > 0)
+                {
+                    sb.AppendLine(_buffer.ToString());
+                }
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/tests/MockBroker.Tests/DevCertificateFactoryTests.cs
+++ b/tests/MockBroker.Tests/DevCertificateFactoryTests.cs
@@ -1,0 +1,108 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CrowsNestMqtt.MockAzureEventGridBroker;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="DevCertificateFactory.CreateSelfSignedPfxBytes"/>.
+/// The factory produces the self-signed cert consumed by <see cref="MockBroker"/>
+/// when TLS is enabled; these tests pin its output shape so a regression there
+/// surfaces immediately without needing to spin up the MQTT listener.
+/// </summary>
+public sealed class DevCertificateFactoryTests
+{
+    [Fact]
+    public void CreateSelfSignedPfxBytes_ReturnsLoadablePfxWithPrivateKey()
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes("127.0.0.1");
+
+        Assert.NotNull(pfx);
+        Assert.NotEmpty(pfx);
+
+        using var cert = X509CertificateLoader.LoadPkcs12(
+            pfx,
+            password: null,
+            keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+
+        Assert.True(cert.HasPrivateKey, "PFX must contain a private key so MqttServer can complete TLS handshake.");
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("localhost")]
+    [InlineData("mock-eg.dev.local")]
+    public void CreateSelfSignedPfxBytes_SubjectCnContainsHostname(string hostname)
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes(hostname);
+        using var cert = X509CertificateLoader.LoadPkcs12(pfx, password: null);
+
+        Assert.Contains($"CN={hostname}", cert.Subject, StringComparison.Ordinal);
+        Assert.Contains("O=CrowsNestMqtt Mock Event Grid", cert.Subject, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateSelfSignedPfxBytes_DeclaresServerAuthEnhancedKeyUsage()
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes("localhost");
+        using var cert = X509CertificateLoader.LoadPkcs12(pfx, password: null);
+
+        var eku = cert.Extensions.OfType<X509EnhancedKeyUsageExtension>().Single();
+        Assert.Contains(eku.EnhancedKeyUsages.Cast<Oid>(), oid => oid.Value == "1.3.6.1.5.5.7.3.1");
+    }
+
+    [Fact]
+    public void CreateSelfSignedPfxBytes_DeclaresDigitalSignatureAndKeyEnciphermentUsage()
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes("localhost");
+        using var cert = X509CertificateLoader.LoadPkcs12(pfx, password: null);
+
+        var usage = cert.Extensions.OfType<X509KeyUsageExtension>().Single();
+        Assert.True(usage.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature));
+        Assert.True(usage.KeyUsages.HasFlag(X509KeyUsageFlags.KeyEncipherment));
+    }
+
+    [Fact]
+    public void CreateSelfSignedPfxBytes_SubjectAlternativeNamesIncludeHostnameLocalhostAndLoopback()
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes("mock-eg.dev.local");
+        using var cert = X509CertificateLoader.LoadPkcs12(pfx, password: null);
+
+        var san = cert.Extensions
+            .FirstOrDefault(e => string.Equals(e.Oid?.Value, "2.5.29.17", StringComparison.Ordinal));
+        Assert.NotNull(san);
+
+        var rendered = san!.Format(multiLine: true);
+        Assert.Contains("mock-eg.dev.local", rendered, StringComparison.Ordinal);
+        Assert.Contains("localhost", rendered, StringComparison.Ordinal);
+        Assert.Contains("127.0.0.1", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateSelfSignedPfxBytes_ValidityIsApproximatelyOneYear()
+    {
+        var pfx = DevCertificateFactory.CreateSelfSignedPfxBytes("localhost");
+        using var cert = X509CertificateLoader.LoadPkcs12(pfx, password: null);
+
+        var lifespan = cert.NotAfter - cert.NotBefore;
+        // The factory sets NotBefore = now-5min, NotAfter = NotBefore + 1 year.
+        // Tolerate a few minutes of drift in either direction.
+        Assert.InRange(lifespan.TotalDays, 364, 367);
+    }
+
+    [Fact]
+    public void CreateSelfSignedPfxBytes_ProducesDistinctCertsOnEachCall()
+    {
+        // Each invocation generates a fresh RSA key, so two adjacent calls must
+        // yield certs with different thumbprints. This proves the factory isn't
+        // caching a static instance behind the scenes.
+        var first = DevCertificateFactory.CreateSelfSignedPfxBytes("localhost");
+        var second = DevCertificateFactory.CreateSelfSignedPfxBytes("localhost");
+
+        using var certA = X509CertificateLoader.LoadPkcs12(first, password: null);
+        using var certB = X509CertificateLoader.LoadPkcs12(second, password: null);
+
+        Assert.NotEqual(certA.Thumbprint, certB.Thumbprint);
+    }
+}

--- a/tests/MockBroker.Tests/MockBroker.Tests.csproj
+++ b/tests/MockBroker.Tests/MockBroker.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>CrowsNestMqtt.MockBrokerTests</RootNamespace>
+    <AssemblyName>CrowsNestMqtt.MockBrokerTests</AssemblyName>
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MQTTnet" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Default ReferenceOutputAssembly=true so the mock broker's IL is
+         loaded into this test process and coverlet can instrument it. -->
+    <ProjectReference Include="..\..\tools\MockAzureEventGridBroker\MockAzureEventGridBroker.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/MockBroker.Tests/MockBrokerAuthValidationTests.cs
+++ b/tests/MockBroker.Tests/MockBrokerAuthValidationTests.cs
@@ -1,0 +1,171 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.Text;
+using CrowsNestMqtt.MockAzureEventGridBroker;
+using MQTTnet;
+using Xunit;
+
+/// <summary>
+/// Exercises every branch of
+/// <see cref="MockBroker.HandleValidatingConnectionAsync"/> through real
+/// MQTT client CONNECT attempts. Each test spins up its own broker on an
+/// ephemeral port so the tests can run without cross-talk.
+/// </summary>
+public sealed class MockBrokerAuthValidationTests
+{
+    private static readonly TimeSpan LogWaitTimeout = TimeSpan.FromSeconds(10);
+
+    private static async Task<(MockBroker broker, int port, CapturingLogWriter log)> StartBrokerAsync(bool useTls = false)
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, useTls), log);
+        await broker.StartAsync();
+        return (broker, port, log);
+    }
+
+    private static MqttClientOptionsBuilder BaseClientOptions(int port, string clientId) =>
+        new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer("127.0.0.1", port)
+            .WithClientId(clientId);
+
+    [Fact]
+    public async Task Connect_WithoutEnhancedAuth_IsRejected_WithMissingMethodMessage()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-no-enhanced-auth").Build();
+
+        await TryConnectAsync(client, options);
+
+        var rejected = await log.WaitForLineAsync(
+            l => l.Contains("expected AuthenticationMethod 'OAUTH2-JWT'", StringComparison.Ordinal)
+              && l.Contains("got '(null)'", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(rejected, $"Expected rejection log missing. Rendered log:\n{log.RenderedLog}");
+    }
+
+    [Fact]
+    public async Task Connect_WithWrongAuthMethod_IsRejected_AndLogsSuppliedMethod()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-wrong-method")
+            .WithEnhancedAuthentication("SCRAM-SHA-1", Encoding.UTF8.GetBytes("does-not-matter"))
+            .Build();
+
+        await TryConnectAsync(client, options);
+
+        var rejected = await log.WaitForLineAsync(
+            l => l.Contains("got 'SCRAM-SHA-1'", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(rejected, $"Expected 'got SCRAM-SHA-1' message missing. Rendered log:\n{log.RenderedLog}");
+    }
+
+    [Fact]
+    public async Task Connect_WithEmptyAuthData_IsRejected_WithNotAuthorized()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-empty-data")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Array.Empty<byte>())
+            .Build();
+
+        await TryConnectAsync(client, options);
+
+        var rejected = await log.WaitForLineAsync(
+            l => l.Contains("AuthenticationData is empty", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(rejected, $"Expected empty-data rejection log missing. Rendered log:\n{log.RenderedLog}");
+    }
+
+    [Fact]
+    public async Task Connect_WithMalformedJwt_IsRejected_WithNotAuthorized()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-malformed-jwt")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes("not-a-real-jwt"))
+            .Build();
+
+        await TryConnectAsync(client, options);
+
+        var rejected = await log.WaitForLineAsync(
+            l => l.Contains("is not a valid JWT", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(rejected, $"Expected malformed-JWT rejection log missing. Rendered log:\n{log.RenderedLog}");
+    }
+
+    [Fact]
+    public async Task Connect_WithValidJwt_IsAccepted_AndLogsSubjectAndExpiry()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        var jwt = TestHelpers.BuildJwt(subject: "aspire-user");
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-valid-jwt")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var result = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        Assert.Equal(MqttClientConnectResultCode.Success, result.ResultCode);
+
+        var accepted = await log.WaitForLineAsync(
+            l => l.Contains("Accepted CONNECT", StringComparison.Ordinal)
+              && l.Contains("sub=aspire-user", StringComparison.Ordinal)
+              && !l.Contains("exp=(no exp)", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(accepted, $"Expected acceptance-with-sub log missing. Rendered log:\n{log.RenderedLog}");
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task Connect_WithJwtMissingExp_IsAccepted_AndLogsNoExpPlaceholder()
+    {
+        var (broker, port, log) = await StartBrokerAsync();
+        await using var brokerHandle = broker;
+
+        var jwt = TestHelpers.BuildJwt(subject: "no-exp-user", omitExpiration: true);
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = BaseClientOptions(port, "connect-jwt-no-exp")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var result = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        Assert.Equal(MqttClientConnectResultCode.Success, result.ResultCode);
+
+        var accepted = await log.WaitForLineAsync(
+            l => l.Contains("Accepted CONNECT", StringComparison.Ordinal)
+              && l.Contains("exp=(no exp)", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(accepted, $"Expected 'exp=(no exp)' log missing. Rendered log:\n{log.RenderedLog}");
+
+        await client.DisconnectAsync();
+    }
+
+    private static async Task TryConnectAsync(IMqttClient client, MqttClientOptions options)
+    {
+        // The broker may surface a rejection either as a non-Success result code
+        // or as a thrown exception depending on MQTTnet's build. Either shape is
+        // acceptable for the tests in this file; we only care about the
+        // broker's captured log.
+        try
+        {
+            _ = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex) when (ex is MQTTnet.Adapter.MqttConnectingFailedException or MQTTnet.Exceptions.MqttCommunicationException)
+        {
+        }
+    }
+}

--- a/tests/MockBroker.Tests/MockBrokerInboundAuthPacketTests.cs
+++ b/tests/MockBroker.Tests/MockBrokerInboundAuthPacketTests.cs
@@ -1,0 +1,140 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.Text;
+using CrowsNestMqtt.MockAzureEventGridBroker;
+using MQTTnet;
+using MQTTnet.Protocol;
+using Xunit;
+
+/// <summary>
+/// Covers <see cref="MockBroker.HandleInboundPacketAsync"/>. The interesting
+/// branches are triggered by MQTT v5 AUTH packets (client-initiated
+/// re-authentication) and by any non-AUTH packet flowing through the same
+/// interceptor.
+/// </summary>
+public sealed class MockBrokerInboundAuthPacketTests
+{
+    private static readonly TimeSpan LogWaitTimeout = TimeSpan.FromSeconds(10);
+
+    private static async Task<(IMqttClient client, MockBroker broker, CapturingLogWriter log)> ConnectAsync(string clientId)
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+        await broker.StartAsync();
+
+        var jwt = TestHelpers.BuildJwt();
+        var client = new MqttClientFactory().CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer("127.0.0.1", port)
+            .WithClientId(clientId)
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var connectResult = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        Assert.Equal(MqttClientConnectResultCode.Success, connectResult.ResultCode);
+
+        return (client, broker, log);
+    }
+
+    [Fact]
+    public async Task Reauth_WithValidJwt_LogsJwtSubject()
+    {
+        var (client, broker, log) = await ConnectAsync("reauth-valid");
+        await using var brokerHandle = broker;
+        using var clientHandle = client;
+
+        var refreshed = TestHelpers.BuildJwt(subject: "refreshed-sub");
+        await client.SendEnhancedAuthenticationExchangeDataAsync(
+            new MqttEnhancedAuthenticationExchangeData
+            {
+                AuthenticationData = Encoding.UTF8.GetBytes(refreshed),
+                ReasonCode = MqttAuthenticateReasonCode.ReAuthenticate,
+            },
+            TestContext.Current.CancellationToken);
+
+        var logged = await log.WaitForLineAsync(
+            l => l.Contains("Received AUTH (method=OAUTH2-JWT", StringComparison.Ordinal)
+              && l.Contains("reason=ReAuthenticate", StringComparison.Ordinal)
+              && l.Contains("JWT sub=refreshed-sub", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(logged, $"Expected re-auth log missing. Rendered log:\n{log.RenderedLog}");
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task Reauth_WithGarbageData_LogsJwtParseFailure()
+    {
+        var (client, broker, log) = await ConnectAsync("reauth-garbage");
+        await using var brokerHandle = broker;
+        using var clientHandle = client;
+
+        await client.SendEnhancedAuthenticationExchangeDataAsync(
+            new MqttEnhancedAuthenticationExchangeData
+            {
+                AuthenticationData = Encoding.UTF8.GetBytes("not-a-jwt-at-all"),
+                ReasonCode = MqttAuthenticateReasonCode.ReAuthenticate,
+            },
+            TestContext.Current.CancellationToken);
+
+        var logged = await log.WaitForLineAsync(
+            l => l.Contains("Received AUTH", StringComparison.Ordinal)
+              && l.Contains("JWT parse failed", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(logged, $"Expected 'JWT parse failed' log missing. Rendered log:\n{log.RenderedLog}");
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task Reauth_WithEmptyData_LogsZeroDataBytesAndSkipsJwtParse()
+    {
+        var (client, broker, log) = await ConnectAsync("reauth-empty");
+        await using var brokerHandle = broker;
+        using var clientHandle = client;
+
+        await client.SendEnhancedAuthenticationExchangeDataAsync(
+            new MqttEnhancedAuthenticationExchangeData
+            {
+                AuthenticationData = Array.Empty<byte>(),
+                ReasonCode = MqttAuthenticateReasonCode.ReAuthenticate,
+            },
+            TestContext.Current.CancellationToken);
+
+        var logged = await log.WaitForLineAsync(
+            l => l.Contains("Received AUTH", StringComparison.Ordinal)
+              && l.Contains("data-bytes=0", StringComparison.Ordinal)
+              && !l.Contains("JWT sub=", StringComparison.Ordinal)
+              && !l.Contains("JWT parse failed", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(logged, $"Expected empty-data AUTH log missing. Rendered log:\n{log.RenderedLog}");
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task NonAuthPackets_DoNotEmitReceivedAuthLog()
+    {
+        var (client, broker, log) = await ConnectAsync("non-auth-packet");
+        await using var brokerHandle = broker;
+        using var clientHandle = client;
+
+        // A publish flows through the same inbound interceptor but is not an
+        // MqttAuthPacket, so it must take the early-return branch.
+        var msg = new MqttApplicationMessageBuilder()
+            .WithTopic("mock-eg/tests/publish")
+            .WithPayload("payload")
+            .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+            .Build();
+        _ = await client.PublishAsync(msg, TestContext.Current.CancellationToken);
+
+        // Give the broker a moment to process the packet.
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(log.Lines, l => l.Contains("Received AUTH", StringComparison.Ordinal));
+
+        await client.DisconnectAsync();
+    }
+}

--- a/tests/MockBroker.Tests/MockBrokerLifecycleTests.cs
+++ b/tests/MockBroker.Tests/MockBrokerLifecycleTests.cs
@@ -1,0 +1,201 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.Net.Sockets;
+using System.Text;
+using CrowsNestMqtt.MockAzureEventGridBroker;
+using MQTTnet;
+using Xunit;
+
+/// <summary>
+/// End-to-end lifecycle tests for <see cref="MockBroker"/>. These cover the
+/// non-TLS and TLS branches of <see cref="MockBroker.StartAsync"/>, the
+/// ephemeral-port fallback path, and shutdown behavior. A real MQTTnet v5
+/// client is used so we exercise the full server plumbing rather than mocking
+/// the event args.
+/// </summary>
+public sealed class MockBrokerLifecycleTests
+{
+    private static readonly TimeSpan LogWaitTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task StartAsync_NonTls_BindsAndAcceptsClientWithOAuth2Jwt()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+
+        var boundPort = await broker.StartAsync();
+        Assert.Equal(port, boundPort);
+        Assert.Equal(port, broker.BoundPort);
+
+        var jwt = TestHelpers.BuildJwt();
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer("127.0.0.1", port)
+            .WithClientId("lifecycle-nontls")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var connectResult = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        Assert.Equal(MqttClientConnectResultCode.Success, connectResult.ResultCode);
+
+        var accepted = await log.WaitForLineAsync(
+            l => l.Contains("Accepted CONNECT (method=OAUTH2-JWT", StringComparison.Ordinal),
+            LogWaitTimeout);
+        Assert.True(accepted, "Broker log did not contain the expected acceptance line. Rendered log:\n" + log.RenderedLog);
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_Tls_BindsAndAcceptsClientOverTls()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: true), log);
+
+        await broker.StartAsync();
+
+        var jwt = TestHelpers.BuildJwt();
+        using var client = new MqttClientFactory().CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+            .WithTcpServer("127.0.0.1", port)
+            .WithTlsOptions(o =>
+            {
+                o.UseTls();
+                o.WithAllowUntrustedCertificates(true);
+                o.WithIgnoreCertificateChainErrors(true);
+                o.WithCertificateValidationHandler(_ => true);
+            })
+            .WithClientId("lifecycle-tls")
+            .WithEnhancedAuthentication("OAUTH2-JWT", Encoding.UTF8.GetBytes(jwt))
+            .Build();
+
+        var connectResult = await client.ConnectAsync(options, TestContext.Current.CancellationToken);
+        Assert.Equal(MqttClientConnectResultCode.Success, connectResult.ResultCode);
+
+        await client.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_WritesListeningLineToLogSink()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+
+        await broker.StartAsync();
+
+        Assert.Contains(log.Lines, l => l == $"{MockBroker.ListeningStdoutPrefix}127.0.0.1:{port}");
+    }
+
+    [Fact]
+    public async Task StartAsync_EmitsStartupAndStartedLogLines()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+
+        await broker.StartAsync();
+
+        Assert.Contains(log.Lines, l => l.Contains("Starting mock Azure Event Grid broker", StringComparison.Ordinal));
+        Assert.Contains(log.Lines, l => l.Contains("Mock broker started", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StartAsync_WithNullPort_AllocatesEphemeralPort()
+    {
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", Port: null, UseTls: false), log);
+
+        var bound = await broker.StartAsync();
+        Assert.InRange(bound, 1, 65535);
+        Assert.Equal(bound, broker.BoundPort);
+
+        // Prove the ephemeral port is actually reachable.
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync("127.0.0.1", bound, TestContext.Current.CancellationToken);
+        Assert.True(tcp.Connected);
+    }
+
+    [Fact]
+    public async Task StartAsync_CalledTwice_Throws()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+
+        await broker.StartAsync();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => broker.StartAsync());
+    }
+
+    [Fact]
+    public async Task Ctor_NullOptions_Throws()
+    {
+        await Task.Yield();
+        Assert.Throws<ArgumentNullException>(() => new MockBroker(null!));
+    }
+
+    [Fact]
+    public async Task StartAsync_WithCancelledToken_Throws()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => broker.StartAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task StopAsync_BeforeStart_IsNoOp()
+    {
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", 12345, UseTls: false));
+
+        // Should not throw and should not log anything about stopping.
+        await broker.StopAsync();
+    }
+
+    [Fact]
+    public async Task StopAsync_Twice_IsIdempotent()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+        await broker.StartAsync();
+
+        await broker.StopAsync();
+        await broker.StopAsync(); // second call must be a no-op
+
+        Assert.Contains(log.Lines, l => l.Contains("Mock broker stopped", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_StopsRunningBroker()
+    {
+        var port = TestHelpers.GetFreeTcpPort();
+        var log = new CapturingLogWriter();
+        var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false), log);
+        await broker.StartAsync();
+
+        await broker.DisposeAsync();
+
+        Assert.Contains(log.Lines, l => l.Contains("Mock broker stopped", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DefaultLogSink_IsConsoleOut_WhenNoWriterProvided()
+    {
+        // We can't intercept Console.Out on a running xunit runner without
+        // racing every other test, so we just assert that construction with no
+        // log sink succeeds and StartAsync/StopAsync exercise the default path.
+        var port = TestHelpers.GetFreeTcpPort();
+        await using var broker = new MockBroker(new MockBrokerOptions("127.0.0.1", port, UseTls: false));
+
+        await broker.StartAsync();
+        Assert.Equal(port, broker.BoundPort);
+        await broker.StopAsync();
+    }
+}

--- a/tests/MockBroker.Tests/MockBrokerOptionsTests.cs
+++ b/tests/MockBroker.Tests/MockBrokerOptionsTests.cs
@@ -1,0 +1,154 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using CrowsNestMqtt.MockAzureEventGridBroker;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="MockBrokerOptions.FromEnvironment(IReadOnlyDictionary{string,string})"/>. These pin the
+/// env-var contract that <c>src/AppHost</c>, <c>tests/AppHost.Tests</c>, and any
+/// external orchestrator (Aspire, CI) depends on. Only the dictionary overload
+/// is tested so nothing pollutes the ambient process environment.
+/// </summary>
+public sealed class MockBrokerOptionsTests
+{
+    [Fact]
+    public void FromEnvironment_MissingAllVars_ReturnsDefaults()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal));
+
+        Assert.Equal("127.0.0.1", options.Host);
+        Assert.Null(options.Port);
+        Assert.True(options.UseTls);
+    }
+
+    [Fact]
+    public void FromEnvironment_EmptyHost_FallsBackToDefault()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.HostEnvVar] = string.Empty,
+        });
+
+        Assert.Equal("127.0.0.1", options.Host);
+    }
+
+    [Theory]
+    [InlineData("192.168.1.5")]
+    [InlineData("mock-eg.internal")]
+    public void FromEnvironment_CustomHost_IsRespected(string host)
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.HostEnvVar] = host,
+        });
+
+        Assert.Equal(host, options.Host);
+    }
+
+    [Fact]
+    public void FromEnvironment_ValidPort_IsParsed()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.PortEnvVar] = "42069",
+        });
+
+        Assert.Equal(42069, options.Port);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-number")]
+    [InlineData("3.14")]
+    public void FromEnvironment_InvalidPort_LeavesPortNullForEphemeralAllocation(string value)
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.PortEnvVar] = value,
+        });
+
+        Assert.Null(options.Port);
+    }
+
+    [Fact]
+    public void FromEnvironment_UseTlsFalse_IsRespected()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.UseTlsEnvVar] = "false",
+        });
+
+        Assert.False(options.UseTls);
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("TRUE")]
+    [InlineData("True")]
+    public void FromEnvironment_UseTlsTrueVariants_AreAllAccepted(string value)
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.UseTlsEnvVar] = value,
+        });
+
+        Assert.True(options.UseTls);
+    }
+
+    [Fact]
+    public void FromEnvironment_UseTlsUnparseable_Throws()
+    {
+        // Preserves the original Program.Main behavior: bool.Parse throws on
+        // anything other than "true"/"false" (case-insensitive), which is the
+        // signal we want operators to see fast rather than silently defaulting.
+        Assert.Throws<FormatException>(() => MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.UseTlsEnvVar] = "maybe",
+        }));
+    }
+
+    [Fact]
+    public void FromEnvironment_UseTlsEmpty_DefaultsToTrue()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.UseTlsEnvVar] = string.Empty,
+        });
+
+        Assert.True(options.UseTls);
+    }
+
+    [Fact]
+    public void FromEnvironment_AllVarsPresent_ReturnsCombinedOptions()
+    {
+        var options = MockBrokerOptions.FromEnvironment(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [MockBrokerOptions.HostEnvVar] = "10.0.0.7",
+            [MockBrokerOptions.PortEnvVar] = "12345",
+            [MockBrokerOptions.UseTlsEnvVar] = "false",
+        });
+
+        Assert.Equal("10.0.0.7", options.Host);
+        Assert.Equal(12345, options.Port);
+        Assert.False(options.UseTls);
+    }
+
+    [Fact]
+    public void FromEnvironment_NullDictionary_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => MockBrokerOptions.FromEnvironment(null!));
+    }
+
+    [Fact]
+    public void FromEnvironment_ProcessOverload_ReturnsOptions()
+    {
+        // The parameter-less overload snapshots the real process environment.
+        // We can't easily assert specific values without mutating env vars
+        // (which would race with other tests), so we only assert that the call
+        // succeeds and produces an object with a plausible host default.
+        var options = MockBrokerOptions.FromEnvironment();
+
+        Assert.NotNull(options);
+        Assert.False(string.IsNullOrEmpty(options.Host));
+    }
+}

--- a/tests/MockBroker.Tests/TestHelpers.cs
+++ b/tests/MockBroker.Tests/TestHelpers.cs
@@ -1,0 +1,72 @@
+namespace CrowsNestMqtt.MockBrokerTests;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Sockets;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
+
+/// <summary>
+/// Small helpers shared across the mock-broker test suites: free-port
+/// allocation, JWT builders, and a minimal MQTT client factory that trusts the
+/// broker's self-signed certificate.
+/// </summary>
+internal static class TestHelpers
+{
+    private static readonly byte[] HmacKey = Encoding.ASCII.GetBytes("test-key-that-is-long-enough-for-hmac-signing");
+
+    public static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public static string BuildJwt(
+        string subject = "test-user",
+        string issuer = "https://sts.local",
+        string audience = "https://eventgrid.azure.net",
+        DateTime? expires = null,
+        DateTime? notBefore = null,
+        bool omitExpiration = false)
+    {
+        if (omitExpiration)
+        {
+            // JwtSecurityTokenHandler auto-fills exp/nbf/iat via
+            // SetDefaultTimesOnTokenCreation, and CreateToken(descriptor)
+            // ignores that flag in some builds — so we hand-craft a compliant
+            // 3-segment HMAC-signed JWT with no 'exp' claim. The mock broker
+            // only calls ReadJwtToken (no signature validation), but a
+            // syntactically correct signature keeps the token robust across
+            // JwtSecurityTokenHandler versions.
+            var headerJson = JsonSerializer.Serialize(new { alg = "HS256", typ = "JWT" });
+            var payloadJson = JsonSerializer.Serialize(new { iss = issuer, aud = audience, sub = subject });
+            var headerSegment = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(headerJson));
+            var payloadSegment = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
+            var signingInput = $"{headerSegment}.{payloadSegment}";
+
+            using var hmac = new HMACSHA256(HmacKey);
+            var signature = Base64UrlEncoder.Encode(hmac.ComputeHash(Encoding.UTF8.GetBytes(signingInput)));
+            return $"{signingInput}.{signature}";
+        }
+
+        var handler = new JwtSecurityTokenHandler();
+        var identity = new ClaimsIdentity(new[] { new Claim("sub", subject) });
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = identity,
+            Issuer = issuer,
+            Audience = audience,
+            Expires = expires ?? DateTime.UtcNow.AddHours(1),
+            NotBefore = notBefore ?? DateTime.UtcNow.AddMinutes(-5),
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(HmacKey),
+                SecurityAlgorithms.HmacSha256Signature),
+        };
+        return handler.WriteToken(handler.CreateToken(descriptor));
+    }
+}

--- a/tests/MockBroker.Tests/xunit.runner.json
+++ b/tests/MockBroker.Tests/xunit.runner.json
@@ -1,0 +1,11 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1,
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": false,
+  "stopOnFail": false,
+  "longRunningTestSeconds": 120
+}

--- a/tests/UnitTests/CommandParserServiceTests.cs
+++ b/tests/UnitTests/CommandParserServiceTests.cs
@@ -297,4 +297,97 @@ public class CommandParserServiceTests
         Assert.NotNull(result.ErrorMessage);
         Assert.Contains("Invalid arguments for :setauthscope", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
+
+    // --- :setclientid ---
+    [Theory]
+    [InlineData(":setclientid my-client-id", "my-client-id")]
+    [InlineData(":setclientid alkopke-dev", "alkopke-dev")]
+    public void ParseCommand_SetClientId_WithArg_Succeeds(string input, string expected)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetClientId, result.ParsedCommand.Type);
+        Assert.Single(result.ParsedCommand.Arguments);
+        Assert.Equal(expected, result.ParsedCommand.Arguments[0]);
+    }
+
+    [Fact]
+    public void ParseCommand_SetClientId_NoArg_SucceedsWithEmptyArgs()
+    {
+        // :setclientid with no arg is the documented way to clear the value.
+        var result = CommandParserService.ParseCommand(":setclientid", _settings);
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetClientId, result.ParsedCommand.Type);
+        Assert.Empty(result.ParsedCommand.Arguments);
+    }
+
+    [Fact]
+    public void ParseCommand_SetClientId_TooManyArgs_ReturnsFailure()
+    {
+        var result = CommandParserService.ParseCommand(":setclientid a b c", _settings);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.ParsedCommand);
+        Assert.Contains(":setclientid", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // --- :azurewhoami ---
+    [Fact]
+    public void ParseCommand_AzureWhoAmI_NoArgs_Succeeds()
+    {
+        var result = CommandParserService.ParseCommand(":azurewhoami", _settings);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.AzureWhoAmI, result.ParsedCommand.Type);
+        Assert.Empty(result.ParsedCommand.Arguments);
+    }
+
+    [Fact]
+    public void ParseCommand_AzureWhoAmI_WithArgs_ReturnsFailure()
+    {
+        var result = CommandParserService.ParseCommand(":azurewhoami extra", _settings);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.ParsedCommand);
+    }
+
+    // --- :setsubscription ---
+    [Theory]
+    [InlineData(":setsubscription sensors/#", "sensors/#")]
+    [InlineData(":setsubscription devices/+/telemetry", "devices/+/telemetry")]
+    public void ParseCommand_SetSubscription_WithArg_Succeeds(string input, string expected)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetSubscriptionTopic, result.ParsedCommand.Type);
+        Assert.Single(result.ParsedCommand.Arguments);
+        Assert.Equal(expected, result.ParsedCommand.Arguments[0]);
+    }
+
+    [Fact]
+    public void ParseCommand_SetSubscription_NoArg_SucceedsWithEmptyArgs()
+    {
+        var result = CommandParserService.ParseCommand(":setsubscription", _settings);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetSubscriptionTopic, result.ParsedCommand.Type);
+        Assert.Empty(result.ParsedCommand.Arguments);
+    }
+
+    [Fact]
+    public void ParseCommand_SetSubscription_TooManyArgs_ReturnsFailure()
+    {
+        var result = CommandParserService.ParseCommand(":setsubscription a b", _settings);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(":setsubscription", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/UnitTests/CommandParserServiceTests.cs
+++ b/tests/UnitTests/CommandParserServiceTests.cs
@@ -240,6 +240,8 @@ public class CommandParserServiceTests
     [InlineData(":setauthmode anonymous", "anonymous")]
     [InlineData(":setauthmode userpass", "userpass")]
     [InlineData(":setauthmode enhanced", "enhanced")]
+    [InlineData(":setauthmode azure", "azure")]
+    [InlineData(":setauthmode Azure", "Azure")] // Case is preserved in arguments; parser is case-insensitive
     public void ParseCommand_SetAuthMode_ValidModes_ReturnsSuccess(string input, string expectedMode)
     {
         var result = CommandParserService.ParseCommand(input, _settings);
@@ -265,5 +267,34 @@ public class CommandParserServiceTests
         Assert.Null(result.ParsedCommand);
         Assert.NotNull(result.ErrorMessage);
         Assert.Contains("Invalid arguments for :setauthmode", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // --- Specific Command Logic: SetAuthScope (Azure Event Grid) ---
+    [Theory]
+    [InlineData(":setauthscope https://eventgrid.azure.net/.default", "https://eventgrid.azure.net/.default")]
+    [InlineData(":setauthscope api://custom-scope/.default", "api://custom-scope/.default")]
+    public void ParseCommand_SetAuthScope_ValidScopes_ReturnsSuccess(string input, string expectedScope)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.True(result.IsSuccess, $"Input '{input}' failed: {result.ErrorMessage}");
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetAuthScope, result.ParsedCommand.Type);
+        Assert.NotNull(result.ParsedCommand.Arguments);
+        Assert.Single(result.ParsedCommand.Arguments);
+        Assert.Equal(expectedScope, result.ParsedCommand.Arguments[0]);
+    }
+
+    [Theory]
+    [InlineData(":setauthscope")]
+    [InlineData(":setauthscope scope1 scope2")]
+    public void ParseCommand_SetAuthScope_InvalidUsage_ReturnsFailure(string input)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.ParsedCommand);
+        Assert.NotNull(result.ErrorMessage);
+        Assert.Contains("Invalid arguments for :setauthscope", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using MQTTnet;
 using MQTTnet.Protocol;
@@ -407,5 +408,56 @@ public class MqttEngineTests
         // Assert
         Assert.NotNull(options);
         Assert.IsType<MqttClientTcpOptions>(options.ChannelOptions);
+    }
+
+    // --- Azure (OAUTH2-JWT) tests ---
+
+    [Fact]
+    public void BuildMqttOptionsCore_WithAzureAuth_SetsOauth2JwtMethodAndToken()
+    {
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "ns.eastus-1.ts.eventgrid.azure.net",
+            Port = 8883,
+            AuthMode = new AzureAuthenticationMode("https://eventgrid.azure.net/.default"),
+        };
+        using var engine = new MqttEngine(settings);
+
+        var expiry = DateTimeOffset.UtcNow.AddHours(1);
+        var token = new CrowsNestMqtt.BusinessLogic.Services.AccessTokenResult("test-azure-token", expiry);
+
+        var methodInfo = typeof(MqttEngine).GetMethod(
+            "BuildMqttOptionsCore",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, new object?[] { token }) as MqttClientOptions;
+
+        Assert.NotNull(options);
+        Assert.Equal("OAUTH2-JWT", options.AuthenticationMethod);
+        Assert.Equal("test-azure-token", System.Text.Encoding.UTF8.GetString(options.AuthenticationData));
+        // Azure always uses TLS regardless of the explicit UseTls setting.
+        Assert.NotNull(options.ChannelOptions);
+        var tlsOptions = options.ChannelOptions.TlsOptions;
+        Assert.NotNull(tlsOptions);
+        Assert.True(tlsOptions!.UseTls);
+    }
+
+    [Fact]
+    public void BuildMqttOptionsCore_WithAzureAuth_ThrowsWhenTokenMissing()
+    {
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "ns.eastus-1.ts.eventgrid.azure.net",
+            Port = 8883,
+            AuthMode = new AzureAuthenticationMode(),
+        };
+        using var engine = new MqttEngine(settings);
+
+        var methodInfo = typeof(MqttEngine).GetMethod(
+            "BuildMqttOptionsCore",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => methodInfo?.Invoke(engine, new object?[] { null }));
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
     }
 }

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -164,6 +164,49 @@ namespace CrowsNestMqtt.UnitTests
         }
 
         [Fact]
+        public void EnvironmentSettingsOverrides_ParsesAzureAuthMode()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", "azure");
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_SCOPE", "api://custom/.default");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.HasOverrides);
+                Assert.IsType<AzureAuthenticationMode>(result.AuthMode);
+                Assert.Equal("api://custom/.default", ((AzureAuthenticationMode)result.AuthMode!).Scope);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_SCOPE", null);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentSettingsOverrides_ParsesAzureAuthMode_DefaultScopeWhenAbsent()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", "azure");
+                // Intentionally not setting CROWSNEST__AUTH_SCOPE
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.HasOverrides);
+                var azure = Assert.IsType<AzureAuthenticationMode>(result.AuthMode);
+                Assert.Null(azure.Scope);
+                Assert.Equal(AzureAuthenticationMode.DefaultScope, azure.EffectiveScope);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_MODE", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__AUTH_SCOPE", null);
+            }
+        }
+
+        [Fact]
         public void EnvironmentSettingsOverrides_ParsesAllCrowsnestVars()
         {
             // Arrange

--- a/tests/UnitTests/Services/AzureAccessTokenProviderTests.cs
+++ b/tests/UnitTests/Services/AzureAccessTokenProviderTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+using CrowsNestMqtt.BusinessLogic.Services;
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests.Services;
+
+public class AzureAccessTokenProviderTests
+{
+    /// <summary>Test stub credential that returns a canned token.</summary>
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public string Token { get; }
+        public DateTimeOffset ExpiresOn { get; }
+        public int CallCount { get; private set; }
+
+        public StubTokenCredential(string token, DateTimeOffset expiresOn)
+        {
+            Token = token;
+            ExpiresOn = expiresOn;
+        }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return new AccessToken(Token, ExpiresOn);
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return new ValueTask<AccessToken>(new AccessToken(Token, ExpiresOn));
+        }
+    }
+
+    [Fact]
+    public void Ctor_NullScope_Throws()
+    {
+        var credential = new StubTokenCredential("token", DateTimeOffset.UtcNow.AddHours(1));
+        Assert.Throws<ArgumentException>(() => new AzureAccessTokenProvider(null!, credential));
+    }
+
+    [Fact]
+    public void Ctor_EmptyScope_Throws()
+    {
+        var credential = new StubTokenCredential("token", DateTimeOffset.UtcNow.AddHours(1));
+        Assert.Throws<ArgumentException>(() => new AzureAccessTokenProvider("   ", credential));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_DelegatesToCredential()
+    {
+        var expiry = DateTimeOffset.UtcNow.AddHours(1);
+        var credential = new StubTokenCredential("my-token", expiry);
+        var provider = new AzureAccessTokenProvider("https://eventgrid.azure.net/.default", credential);
+
+        var result = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Equal("my-token", result.Token);
+        Assert.Equal(expiry, result.ExpiresOn);
+        Assert.Equal(1, credential.CallCount);
+    }
+
+    [Fact]
+    public void AzureAuthenticationMode_DefaultScopeUsedWhenNullOrWhitespace()
+    {
+        var mode = new AzureAuthenticationMode();
+        Assert.Equal(AzureAuthenticationMode.DefaultScope, mode.EffectiveScope);
+
+        var blank = new AzureAuthenticationMode("   ");
+        Assert.Equal(AzureAuthenticationMode.DefaultScope, blank.EffectiveScope);
+    }
+
+    [Fact]
+    public void AzureAuthenticationMode_CustomScopeUsedWhenProvided()
+    {
+        var custom = new AzureAuthenticationMode("api://my-app/.default");
+        Assert.Equal("api://my-app/.default", custom.EffectiveScope);
+    }
+
+    [Fact]
+    public void AzureAuthenticationMode_AuthMethodConstant()
+    {
+        // Azure Event Grid requires exactly this method name on the CONNECT packet.
+        Assert.Equal("OAUTH2-JWT", AzureAuthenticationMode.AuthenticationMethod);
+    }
+
+    // --- CROWSNEST__AZURE_TOKEN_OVERRIDE seam tests ---
+
+    private static string BuildJwt(DateTime expiresUtc)
+    {
+        var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+        var key = System.Text.Encoding.ASCII.GetBytes("test-key-that-is-long-enough-for-hmac-signing");
+        var descriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Subject = new System.Security.Claims.ClaimsIdentity(new[]
+            {
+                new System.Security.Claims.Claim("sub", "unit-test-user"),
+            }),
+            Expires = expiresUtc,
+            Issuer = "https://sts.local",
+            Audience = "https://eventgrid.azure.net",
+            SigningCredentials = new Microsoft.IdentityModel.Tokens.SigningCredentials(
+                new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(key),
+                Microsoft.IdentityModel.Tokens.SecurityAlgorithms.HmacSha256Signature),
+        };
+        return handler.WriteToken(handler.CreateToken(descriptor));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_WithEnvOverride_ReturnsOverrideAndBypassesCredential()
+    {
+        var expiry = DateTime.UtcNow.AddMinutes(30);
+        var overrideJwt = BuildJwt(expiry);
+        var credential = new StubTokenCredential("should-not-be-used", DateTimeOffset.UtcNow.AddDays(1));
+        var provider = new AzureAccessTokenProvider("https://eventgrid.azure.net/.default", credential);
+
+        Environment.SetEnvironmentVariable(AzureAccessTokenProvider.TokenOverrideEnvVar, overrideJwt);
+        try
+        {
+            var result = await provider.GetTokenAsync(CancellationToken.None);
+
+            Assert.Equal(overrideJwt, result.Token);
+            // Expiry comes from the JWT exp claim (truncated to second precision by the JWT handler).
+            Assert.Equal(expiry, result.ExpiresOn.UtcDateTime, TimeSpan.FromSeconds(1));
+            Assert.Equal(0, credential.CallCount);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AzureAccessTokenProvider.TokenOverrideEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_WithEnvOverride_MalformedJwt_UsesFallbackExpiry()
+    {
+        var credential = new StubTokenCredential("should-not-be-used", DateTimeOffset.UtcNow.AddDays(1));
+        var provider = new AzureAccessTokenProvider("https://eventgrid.azure.net/.default", credential);
+
+        Environment.SetEnvironmentVariable(AzureAccessTokenProvider.TokenOverrideEnvVar, "not-a-real-jwt");
+        try
+        {
+            var before = DateTimeOffset.UtcNow;
+            var result = await provider.GetTokenAsync(CancellationToken.None);
+
+            Assert.Equal("not-a-real-jwt", result.Token);
+            // Fallback: UtcNow + 1h. Allow a generous window around 1h.
+            var expectedMin = before.AddMinutes(55);
+            var expectedMax = before.AddMinutes(65);
+            Assert.InRange(result.ExpiresOn, expectedMin, expectedMax);
+            Assert.Equal(0, credential.CallCount);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AzureAccessTokenProvider.TokenOverrideEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_WithoutEnvOverride_UsesCredentialAsBefore()
+    {
+        // Make absolutely sure the env var is not lingering from another test.
+        Environment.SetEnvironmentVariable(AzureAccessTokenProvider.TokenOverrideEnvVar, null);
+
+        var expiry = DateTimeOffset.UtcNow.AddHours(2);
+        var credential = new StubTokenCredential("from-credential", expiry);
+        var provider = new AzureAccessTokenProvider("https://eventgrid.azure.net/.default", credential);
+
+        var result = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Equal("from-credential", result.Token);
+        Assert.Equal(expiry, result.ExpiresOn);
+        Assert.Equal(1, credential.CallCount);
+    }
+
+    [Fact]
+    public void ReadJwtExpiryOrFallback_ValidJwt_ReturnsExpClaim()
+    {
+        var expiry = DateTime.UtcNow.AddMinutes(15);
+        var jwt = BuildJwt(expiry);
+
+        var result = AzureAccessTokenProvider.ReadJwtExpiryOrFallback(jwt);
+
+        Assert.Equal(expiry, result.UtcDateTime, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void ReadJwtExpiryOrFallback_MalformedJwt_ReturnsOneHourFallback()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var result = AzureAccessTokenProvider.ReadJwtExpiryOrFallback("junk-not-a-jwt");
+
+        Assert.InRange(result, before.AddMinutes(55), before.AddMinutes(65));
+    }
+}

--- a/tests/UnitTests/Services/CommandParserServiceTests.cs
+++ b/tests/UnitTests/Services/CommandParserServiceTests.cs
@@ -43,7 +43,7 @@ namespace CrowsNestMqtt.UnitTests.Services
             // Assert
             Assert.False(result.IsSuccess);
             Assert.Null(result.ParsedCommand);
-            Assert.Equal("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced>", result.ErrorMessage);
+            Assert.Equal("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced|azure>", result.ErrorMessage);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace CrowsNestMqtt.UnitTests.Services
             // Assert
             Assert.False(result.IsSuccess);
             Assert.Null(result.ParsedCommand);
-            Assert.Equal("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced>", result.ErrorMessage);
+            Assert.Equal("Invalid arguments for :setauthmode. Expected: :setauthmode <anonymous|userpass|enhanced|azure>", result.ErrorMessage);
         }
 
         // Tests for :setuser

--- a/tests/UnitTests/Services/EnhancedAuthenticationHandlerTests.cs
+++ b/tests/UnitTests/Services/EnhancedAuthenticationHandlerTests.cs
@@ -48,7 +48,7 @@ public class EnhancedAuthenticationHandlerTests
             handler.Configure();
 
             // Assert
-            Assert.Contains(logMessages, log => log.Contains("Enhanced Authentication: Token is valid until"));
+            Assert.Contains(logMessages, log => log.Contains("Enhanced Authentication (K8S-SAT): Token is valid until"));
         }
         finally
         {
@@ -75,7 +75,7 @@ public class EnhancedAuthenticationHandlerTests
             handler.Configure();
 
             // Assert
-            Assert.Contains(logMessages, log => log.Contains("Enhanced Authentication: Token has expired on"));
+            Assert.Contains(logMessages, log => log.Contains("Enhanced Authentication (K8S-SAT): Token has expired on"));
         }
         finally
         {
@@ -132,6 +132,72 @@ public class EnhancedAuthenticationHandlerTests
         finally
         {
             // Cleanup
+            AppLogger.OnLogMessage -= logHandler;
+        }
+    }
+
+    // --- Azure OAUTH2-JWT tests ---
+
+    /// <summary>
+    /// Minimal <see cref="IAccessTokenProvider"/> stub for tests; returns a canned token
+    /// and increments a call counter so tests can assert it was invoked.
+    /// </summary>
+    private sealed class StubAccessTokenProvider : IAccessTokenProvider
+    {
+        public int CallCount { get; private set; }
+        public string Token { get; set; } = "stub-token";
+        public DateTimeOffset ExpiresOn { get; set; } = DateTimeOffset.UtcNow.AddHours(1);
+
+        public Task<AccessTokenResult> GetTokenAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new AccessTokenResult(Token, ExpiresOn));
+        }
+    }
+
+    [Fact]
+    public void Configure_WithAzureMode_AssignsHandlerToOptions()
+    {
+        var validToken = GenerateTestToken(DateTime.UtcNow.AddHours(1));
+        var options = new MqttClientOptions
+        {
+            AuthenticationMethod = "OAUTH2-JWT",
+            AuthenticationData = Encoding.UTF8.GetBytes(validToken),
+        };
+        var provider = new StubAccessTokenProvider();
+        var handler = new EnhancedAuthenticationHandler(options, provider);
+
+        handler.Configure();
+
+        Assert.Same(handler, options.EnhancedAuthenticationHandler);
+    }
+
+    [Fact]
+    public void Configure_WithOAuth2Jwt_LogsTokenValidity()
+    {
+        var validToken = GenerateTestToken(DateTime.UtcNow.AddHours(1));
+        var options = new MqttClientOptions
+        {
+            AuthenticationMethod = "OAUTH2-JWT",
+            AuthenticationData = Encoding.UTF8.GetBytes(validToken),
+        };
+        var provider = new StubAccessTokenProvider();
+        var handler = new EnhancedAuthenticationHandler(options, provider);
+
+        var logMessages = new System.Collections.Generic.List<string>();
+        Action<string, string> logHandler = (level, message) =>
+        {
+            if (level == "Information") logMessages.Add(message);
+        };
+        AppLogger.OnLogMessage += logHandler;
+
+        try
+        {
+            handler.Configure();
+            Assert.Contains(logMessages, log => log.Contains("Enhanced Authentication (OAUTH2-JWT): Token is valid until"));
+        }
+        finally
+        {
             AppLogger.OnLogMessage -= logHandler;
         }
     }

--- a/tests/UnitTests/Services/MqttHostnameNormalizerTests.cs
+++ b/tests/UnitTests/Services/MqttHostnameNormalizerTests.cs
@@ -1,0 +1,158 @@
+using CrowsNestMqtt.BusinessLogic.Services;
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests.Services;
+
+public class MqttHostnameNormalizerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Normalize_NullOrWhitespace_ReturnsAsIsWithNoNotes(string? input)
+    {
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.False(result.WasChanged);
+        Assert.Null(result.Port);
+        Assert.Empty(result.Notes);
+    }
+
+    [Theory]
+    [InlineData("broker.hivemq.com")]
+    [InlineData("localhost")]
+    [InlineData("ns.region-1.ts.eventgrid.azure.net")]
+    public void Normalize_AlreadyClean_ReturnsAsIsWithNoNotes(string input)
+    {
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal(input, result.Hostname);
+        Assert.Null(result.Port);
+        Assert.False(result.WasChanged);
+    }
+
+    [Theory]
+    [InlineData("https://broker.example.com", "broker.example.com", "stripped 'https://' scheme")]
+    [InlineData("http://broker.example.com", "broker.example.com", "stripped 'http://' scheme")]
+    [InlineData("mqtt://broker.example.com", "broker.example.com", "stripped 'mqtt://' scheme")]
+    [InlineData("mqtts://broker.example.com", "broker.example.com", "stripped 'mqtts://' scheme")]
+    [InlineData("ws://broker.example.com", "broker.example.com", "stripped 'ws://' scheme")]
+    [InlineData("wss://broker.example.com", "broker.example.com", "stripped 'wss://' scheme")]
+    [InlineData("tcp://broker.example.com", "broker.example.com", "stripped 'tcp://' scheme")]
+    [InlineData("HTTPS://Broker.Example.Com", "Broker.Example.Com", "stripped 'https://' scheme")]
+    public void Normalize_StripsUrlScheme(string input, string expectedHost, string expectedNote)
+    {
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal(expectedHost, result.Hostname);
+        Assert.Contains(expectedNote, result.Notes);
+    }
+
+    [Fact]
+    public void Normalize_StripsPath()
+    {
+        var result = MqttHostnameNormalizer.Normalize("broker.example.com/api/events");
+
+        Assert.Equal("broker.example.com", result.Hostname);
+        Assert.Contains("stripped path '/api/events'", result.Notes);
+    }
+
+    [Fact]
+    public void Normalize_StripsSchemeAndPath()
+    {
+        var result = MqttHostnameNormalizer.Normalize("https://broker.example.com/some/path?x=1");
+
+        Assert.Equal("broker.example.com", result.Hostname);
+        Assert.Contains("stripped 'https://' scheme", result.Notes);
+        Assert.Contains("stripped path '/some/path?x=1'", result.Notes);
+    }
+
+    [Theory]
+    [InlineData("broker.example.com:1883", "broker.example.com", 1883)]
+    [InlineData("broker.example.com:8883", "broker.example.com", 8883)]
+    [InlineData("mqtts://broker.example.com:8883", "broker.example.com", 8883)]
+    [InlineData("https://broker.example.com:443/api", "broker.example.com", 443)]
+    public void Normalize_ExtractsTrailingPort(string input, string expectedHost, int expectedPort)
+    {
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal(expectedHost, result.Hostname);
+        Assert.Equal(expectedPort, result.Port);
+    }
+
+    [Fact]
+    public void Normalize_IgnoresInvalidPortStrings()
+    {
+        var result = MqttHostnameNormalizer.Normalize("broker.example.com:notaport");
+
+        // ':notaport' is not extracted as a port — the whole thing stays as hostname.
+        Assert.Equal("broker.example.com:notaport", result.Hostname);
+        Assert.Null(result.Port);
+    }
+
+    [Fact]
+    public void Normalize_IgnoresOutOfRangePort()
+    {
+        var result = MqttHostnameNormalizer.Normalize("broker.example.com:99999");
+
+        Assert.Equal("broker.example.com:99999", result.Hostname);
+        Assert.Null(result.Port);
+    }
+
+    [Fact]
+    public void Normalize_TrimsWhitespace()
+    {
+        var result = MqttHostnameNormalizer.Normalize("   broker.example.com   ");
+
+        Assert.Equal("broker.example.com", result.Hostname);
+        Assert.Contains("trimmed surrounding whitespace", result.Notes);
+    }
+
+    [Fact]
+    public void Normalize_StripsUserInfoPrefix()
+    {
+        var result = MqttHostnameNormalizer.Normalize("user:pass@broker.example.com:1883");
+
+        Assert.Equal("broker.example.com", result.Hostname);
+        Assert.Equal(1883, result.Port);
+        Assert.Contains("stripped userinfo prefix", result.Notes);
+    }
+
+    // --- Azure Event Grid HTTP → MQTT suffix rewriting ---
+
+    [Fact]
+    public void Normalize_RewritesEventGridHttpToMqttSuffix()
+    {
+        var input = "https://egroutealkopkedev.northeurope-1.eventgrid.azure.net/api/events";
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal("egroutealkopkedev.northeurope-1.ts.eventgrid.azure.net", result.Hostname);
+        Assert.Contains(result.Notes, n => n.Contains("Event Grid HTTP suffix", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Normalize_LeavesEventGridMqttSuffixAlone()
+    {
+        var input = "myns.eastus-1.ts.eventgrid.azure.net";
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal(input, result.Hostname);
+        Assert.DoesNotContain(result.Notes, n => n.Contains("suffix", StringComparison.Ordinal));
+        Assert.False(result.WasChanged);
+    }
+
+    [Fact]
+    public void Normalize_RewriteAppliedAfterSchemeAndPathStripping()
+    {
+        // A single realistic pasted-URL scenario end-to-end.
+        var input = "  HTTPS://EGRoutEAlKopkeDev.northeurope-1.eventgrid.azure.net/api/events  ";
+        var result = MqttHostnameNormalizer.Normalize(input);
+
+        Assert.Equal("EGRoutEAlKopkeDev.northeurope-1.ts.eventgrid.azure.net", result.Hostname);
+        Assert.True(result.WasChanged);
+        Assert.Contains("trimmed surrounding whitespace", result.Notes);
+        Assert.Contains("stripped 'https://' scheme", result.Notes);
+        Assert.Contains("stripped path '/api/events'", result.Notes);
+        Assert.Contains(result.Notes, n => n.Contains("Event Grid", StringComparison.Ordinal));
+    }
+}

--- a/tests/UnitTests/ViewModels/AzureEventGridHostDetectionTests.cs
+++ b/tests/UnitTests/ViewModels/AzureEventGridHostDetectionTests.cs
@@ -1,0 +1,22 @@
+using CrowsNestMqtt.UI.ViewModels;
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests.ViewModels;
+
+public class AzureEventGridHostDetectionTests
+{
+    [Theory]
+    [InlineData("myns.eastus-1.ts.eventgrid.azure.net", true)]
+    [InlineData("MYNS.EASTUS-1.TS.EVENTGRID.AZURE.NET", true)]
+    [InlineData("namespace.westeurope-2.ts.eventgrid.azure.net", true)]
+    [InlineData("broker.hivemq.com", false)]
+    [InlineData("eventgrid.azure.net", false)]                       // missing .ts. infix
+    [InlineData("myns.ts.eventgrid.azure.net.malicious.com", false)] // suffix only, not contains
+    [InlineData("localhost", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsAzureEventGridHost_RecognizesEventGridSuffix(string? host, bool expected)
+    {
+        Assert.Equal(expected, MainViewModel.IsAzureEventGridHost(host));
+    }
+}

--- a/tests/UnitTests/ViewModels/AzureEventGridHostDetectionTests.cs
+++ b/tests/UnitTests/ViewModels/AzureEventGridHostDetectionTests.cs
@@ -9,8 +9,10 @@ public class AzureEventGridHostDetectionTests
     [InlineData("myns.eastus-1.ts.eventgrid.azure.net", true)]
     [InlineData("MYNS.EASTUS-1.TS.EVENTGRID.AZURE.NET", true)]
     [InlineData("namespace.westeurope-2.ts.eventgrid.azure.net", true)]
+    // HTTP data-plane suffix is also recognized so pasted URLs trigger auto-config;
+    // the hostname normalizer then rewrites them to the MQTT topic-space form.
+    [InlineData("myns.northeurope-1.eventgrid.azure.net", true)]
     [InlineData("broker.hivemq.com", false)]
-    [InlineData("eventgrid.azure.net", false)]                       // missing .ts. infix
     [InlineData("myns.ts.eventgrid.azure.net.malicious.com", false)] // suffix only, not contains
     [InlineData("localhost", false)]
     [InlineData("", false)]

--- a/tests/UnitTests/ViewModels/AzureWhoAmIDispatchTests.cs
+++ b/tests/UnitTests/ViewModels/AzureWhoAmIDispatchTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Commands;
+using CrowsNestMqtt.BusinessLogic.Services;
+using CrowsNestMqtt.UI.ViewModels;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using Xunit;
+
+namespace CrowsNestMqtt.UnitTests.ViewModels;
+
+public sealed class AzureWhoAmIDispatchTests : IDisposable
+{
+    private sealed class StubAccessTokenProvider : IAccessTokenProvider
+    {
+        public string Token { get; set; } = string.Empty;
+        public DateTimeOffset ExpiresOn { get; set; } = DateTimeOffset.UtcNow.AddHours(1);
+        public int CallCount { get; private set; }
+        public Exception? ToThrow { get; set; }
+
+        public Task<AccessTokenResult> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (ToThrow is not null)
+            {
+                throw ToThrow;
+            }
+            return Task.FromResult(new AccessTokenResult(Token, ExpiresOn));
+        }
+    }
+
+    private readonly StubAccessTokenProvider _tokenProvider = new();
+    private readonly MainViewModel _viewModel;
+    private readonly MethodInfo _dispatchMethod;
+
+    public AzureWhoAmIDispatchTests()
+    {
+        var parser = Substitute.For<ICommandParserService>();
+        var mqtt = Substitute.For<IMqttService>();
+        _viewModel = new MainViewModel(
+            commandParserService: parser,
+            mqttService: mqtt,
+            uiScheduler: Scheduler.Immediate,
+            azureTokenProviderFactory: _ => _tokenProvider);
+
+        _dispatchMethod = typeof(MainViewModel).GetMethod(
+            "DispatchCommand", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    }
+
+    public void Dispose() => _viewModel.Dispose();
+
+    private void Dispatch(CommandType type, params string[] args)
+    {
+        var command = new ParsedCommand(type, args.ToList().AsReadOnly());
+        _dispatchMethod.Invoke(_viewModel, new object[] { command });
+    }
+
+    private static string BuildJwt(params (string type, string value)[] claims)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes("test-key-that-is-long-enough-for-hmac-signing");
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims.Select(c => new Claim(c.type, c.value))),
+            Expires = DateTime.UtcNow.AddHours(1),
+            Issuer = "https://sts.local",
+            Audience = "https://eventgrid.azure.net",
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(key),
+                SecurityAlgorithms.HmacSha256Signature),
+        };
+        return handler.WriteToken(handler.CreateToken(descriptor));
+    }
+
+    [Fact]
+    public async Task Dispatch_AzureWhoAmI_LogsUpnAndOidAndAppId()
+    {
+        _tokenProvider.Token = BuildJwt(
+            ("upn", "alkopke@example.com"),
+            ("oid", "11111111-2222-3333-4444-555555555555"),
+            ("name", "Alexander Kopke"),
+            ("tid", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            ("idtyp", "user"));
+
+        Dispatch(CommandType.AzureWhoAmI);
+        // ExecuteAzureWhoAmIAsync is dispatched fire-and-forget; poll briefly.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline
+            && !(_viewModel.StatusBarText ?? string.Empty).Contains("Signed in as"))
+        {
+            await Task.Delay(50);
+        }
+
+        Assert.Contains("upn=alkopke@example.com", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Contains("oid=11111111-2222-3333-4444-555555555555", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Contains("name=Alexander Kopke", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Contains(":setclientid", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Equal(1, _tokenProvider.CallCount);
+    }
+
+    [Fact]
+    public async Task Dispatch_AzureWhoAmI_FallsBackToPreferredUsername_WhenUpnMissing()
+    {
+        _tokenProvider.Token = BuildJwt(
+            ("preferred_username", "alkopke@example.com"),
+            ("oid", "abc123"));
+
+        Dispatch(CommandType.AzureWhoAmI);
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline
+            && !(_viewModel.StatusBarText ?? string.Empty).Contains("Signed in as"))
+        {
+            await Task.Delay(50);
+        }
+
+        Assert.Contains("upn=alkopke@example.com", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Contains("oid=abc123", _viewModel.StatusBarText ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task Dispatch_AzureWhoAmI_HandlesCredentialFailureGracefully()
+    {
+        _tokenProvider.ToThrow = new InvalidOperationException("No credentials configured");
+
+        Dispatch(CommandType.AzureWhoAmI);
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline
+            && !(_viewModel.StatusBarText ?? string.Empty).Contains("whoami failed"))
+        {
+            await Task.Delay(50);
+        }
+
+        Assert.Contains("Azure whoami failed", _viewModel.StatusBarText ?? string.Empty);
+        Assert.Contains("az login", _viewModel.StatusBarText ?? string.Empty);
+    }
+}

--- a/tests/UnitTests/ViewModels/DispatchCommandTests.cs
+++ b/tests/UnitTests/ViewModels/DispatchCommandTests.cs
@@ -197,11 +197,73 @@ public class DispatchCommandTests : IDisposable
     }
 
     [Fact]
+    public void DispatchCommand_SetAuthMode_Azure_NudgesTooLowKeepAliveAndSessionExpiry()
+    {
+        // Sub-broker-minimum keep-alive / session-expiry values are a common
+        // trap for Azure Event Grid users. The dispatcher must bump them to
+        // safe defaults so the connection doesn't loop on KeepAliveTimeout /
+        // session-expired failures.
+        _viewModel.Settings.KeepAliveIntervalSeconds = 1;
+        _viewModel.Settings.SessionExpiryIntervalSeconds = 1;
+
+        Dispatch(CommandType.SetAuthMode, "azure");
+
+        Assert.True(_viewModel.Settings.KeepAliveIntervalSeconds >= 30);
+        Assert.True(_viewModel.Settings.SessionExpiryIntervalSeconds >= 300);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetAuthMode_Azure_KeepsAlreadySafeTimingValues()
+    {
+        // If the user already picked reasonable values, respect them.
+        _viewModel.Settings.KeepAliveIntervalSeconds = 90;
+        _viewModel.Settings.SessionExpiryIntervalSeconds = 7200;
+
+        Dispatch(CommandType.SetAuthMode, "azure");
+
+        Assert.Equal(90, _viewModel.Settings.KeepAliveIntervalSeconds);
+        Assert.Equal(7200u, _viewModel.Settings.SessionExpiryIntervalSeconds);
+    }
+
+    [Fact]
     public void DispatchCommand_SetAuthScope_ShouldSetScope()
     {
         Dispatch(CommandType.SetAuthScope, "api://my-app/.default");
         Assert.Equal("api://my-app/.default", _viewModel.Settings.AuthenticationScope);
         Assert.Contains("api://my-app/.default", _viewModel.StatusBarText);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetClientId_WithArg_ShouldSetClientId()
+    {
+        Dispatch(CommandType.SetClientId, "alkopke-dev");
+        Assert.Equal("alkopke-dev", _viewModel.Settings.ClientId);
+        Assert.Contains("alkopke-dev", _viewModel.StatusBarText);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetClientId_NoArgs_ShouldClearClientId()
+    {
+        _viewModel.Settings.ClientId = "previous-value";
+        Dispatch(CommandType.SetClientId);
+        Assert.Null(_viewModel.Settings.ClientId);
+        Assert.Contains("cleared", _viewModel.StatusBarText, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetSubscriptionTopic_WithArg_ShouldSetTopic()
+    {
+        Dispatch(CommandType.SetSubscriptionTopic, "sensors/#");
+        Assert.Equal("sensors/#", _viewModel.Settings.SubscriptionTopic);
+        Assert.Contains("sensors/#", _viewModel.StatusBarText, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetSubscriptionTopic_NoArgs_ShouldResetToHash()
+    {
+        _viewModel.Settings.SubscriptionTopic = "sensors/#";
+        Dispatch(CommandType.SetSubscriptionTopic);
+        Assert.Equal("#", _viewModel.Settings.SubscriptionTopic);
     }
 
     [Fact]
@@ -224,6 +286,28 @@ public class DispatchCommandTests : IDisposable
         Dispatch(CommandType.SetAuthMethod, "SCRAM-SHA-1");
         Assert.Equal("SCRAM-SHA-1", _viewModel.Settings.AuthenticationMethod);
         Assert.Contains("SCRAM-SHA-1", _viewModel.StatusBarText);
+    }
+
+    [Theory]
+    [InlineData("anonymous")]
+    [InlineData("userpass")]
+    [InlineData("enhanced")]
+    [InlineData("azure")]
+    [InlineData("Azure")] // case-insensitive
+    public void DispatchCommand_SetAuthMethod_WithAuthModeName_ShouldRedirectUser(string modeName)
+    {
+        // Regression: users frequently pick :setauthmethod from the alphabetically
+        // sorted command palette when they meant :setauthmode. Rather than
+        // silently writing an auth-mode name into the (mostly unused) enhanced-auth
+        // method field, the dispatcher must reject the input and point the user
+        // at the correct command.
+        var previousMethod = _viewModel.Settings.AuthenticationMethod;
+        Dispatch(CommandType.SetAuthMethod, modeName);
+
+        // AuthenticationMethod must NOT be mutated by this rejected call.
+        Assert.Equal(previousMethod, _viewModel.Settings.AuthenticationMethod);
+        Assert.Contains("Did you mean ':setauthmode", _viewModel.StatusBarText, StringComparison.Ordinal);
+        Assert.Contains(modeName.ToLowerInvariant(), _viewModel.StatusBarText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/UnitTests/ViewModels/DispatchCommandTests.cs
+++ b/tests/UnitTests/ViewModels/DispatchCommandTests.cs
@@ -179,10 +179,29 @@ public class DispatchCommandTests : IDisposable
     }
 
     [Fact]
-    public void DispatchCommand_SetAuthMode_Enhanced_ShouldSetMethod()
+    public void DispatchCommand_SetAuthMode_Enhanced_ShouldSetMode()
     {
         Dispatch(CommandType.SetAuthMode, "enhanced");
-        Assert.Equal("Enhanced Authentication", _viewModel.Settings.AuthenticationMethod);
+        Assert.Equal(SettingsViewModel.AuthModeSelection.Enhanced, _viewModel.Settings.SelectedAuthMode);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetAuthMode_Azure_ShouldSetModeAndAutoConfigure()
+    {
+        Dispatch(CommandType.SetAuthMode, "azure");
+        Assert.Equal(SettingsViewModel.AuthModeSelection.Azure, _viewModel.Settings.SelectedAuthMode);
+        // Selecting Azure forces TLS + port 8883 + TCP transport for Event Grid.
+        Assert.True(_viewModel.Settings.UseTls);
+        Assert.Equal(8883, _viewModel.Settings.Port);
+        Assert.Equal(CrowsNestMqtt.BusinessLogic.Configuration.TransportProtocol.Tcp, _viewModel.Settings.SelectedTransport);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetAuthScope_ShouldSetScope()
+    {
+        Dispatch(CommandType.SetAuthScope, "api://my-app/.default");
+        Assert.Equal("api://my-app/.default", _viewModel.Settings.AuthenticationScope);
+        Assert.Contains("api://my-app/.default", _viewModel.StatusBarText);
     }
 
     [Fact]

--- a/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
+++ b/tests/UnitTests/ViewModels/MqttCommunicationTests.cs
@@ -4,7 +4,9 @@ using CrowsNestMqtt.BusinessLogic.Services;
 using CrowsNestMqtt.UI.ViewModels;
 using NSubstitute;
 using MQTTnet;
+using System;
 using System.Buffers;
+using System.IO;
 using System.Reactive.Linq;
 using Xunit;
 using Avalonia.Threading;
@@ -21,13 +23,36 @@ namespace CrowsNestMqtt.UnitTests.ViewModels
         {
             _commandParserService = Substitute.For<ICommandParserService>();
             _mqttServiceMock = Substitute.For<IMqttService>(); // Substitute the interface
+
+            // Isolate settings persistence to a temp file per test-class instance
+            // so tests that mutate ViewModel.Settings don't leak their state
+            // into subsequent tests via the shared %LOCALAPPDATA%\CrowsNestMqtt\settings.json.
+            _originalSettingsFilePath = SettingsViewModel._settingsFilePath;
+            _tempSettingsFilePath = Path.Combine(
+                Path.GetTempPath(),
+                $"CrowsNestMqtt-tests-{Guid.NewGuid():N}",
+                "settings.json");
+            SettingsViewModel._settingsFilePath = _tempSettingsFilePath;
         }
+
+        private readonly string _originalSettingsFilePath;
+        private readonly string _tempSettingsFilePath;
 
         public void Dispose()
         {
-            // No direct cleanup needed here as each test creates its own ViewModel
-            // and the finally block in the Aspire test handles its disposal.
-            // If a shared ViewModel were used, it would be disposed here.
+            SettingsViewModel._settingsFilePath = _originalSettingsFilePath;
+            try
+            {
+                var dir = Path.GetDirectoryName(_tempSettingsFilePath);
+                if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
         }
 
         [Fact]
@@ -42,6 +67,44 @@ namespace CrowsNestMqtt.UnitTests.ViewModels
             // Assert
             _mqttServiceMock.Received(1).UpdateSettings(Arg.Any<MqttConnectionSettings>());
             _mqttServiceMock.Received(1).ConnectAsync();
+        }
+
+        [Fact]
+        public void ConnectAsync_WithAzureHostname_ButNonAzureAuthMode_ShouldRefuseWithClearMessage()
+        {
+            // Regression: when the hostname is clearly Azure Event Grid but the
+            // auth mode is Anonymous / Userpass / Enhanced, the anonymous CONNECT
+            // is guaranteed to fail with an opaque broker error. Refuse loudly
+            // instead of reconnecting in a loop.
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, null, null, null, uiScheduler: System.Reactive.Concurrency.Scheduler.Immediate);
+            viewModel.Settings.Hostname = "myns.northeurope-1.ts.eventgrid.azure.net";
+            viewModel.Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Anonymous;
+
+            viewModel.ConnectCommand.Execute(System.Reactive.Unit.Default).Subscribe();
+
+            _mqttServiceMock.DidNotReceive().ConnectAsync();
+            _mqttServiceMock.DidNotReceive().UpdateSettings(Arg.Any<MqttConnectionSettings>());
+            Assert.Contains("looks like Azure Event Grid", viewModel.StatusBarText ?? string.Empty, StringComparison.Ordinal);
+            Assert.Contains(":setauthmode azure", viewModel.StatusBarText ?? string.Empty, StringComparison.Ordinal);
+            Assert.True(viewModel.HasConnectionError);
+        }
+
+        [Fact]
+        public void ConnectAsync_WithAzureMode_ButNonEventGridHost_ShouldWarnButProceed()
+        {
+            // Localhost or the mock broker are legitimate Azure-mode targets
+            // (integration testing) — warn softly but let the connect proceed.
+            using var viewModel = new MainViewModel(_commandParserService, _mqttServiceMock, null, null, null, uiScheduler: System.Reactive.Concurrency.Scheduler.Immediate);
+            viewModel.Settings.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+            // SelectedAuthMode setter clobbers Port to 8883 etc., so set hostname AFTER.
+            viewModel.Settings.Hostname = "localhost";
+            viewModel.Settings.ClientId = "some-client-id"; // silence the empty-client-id warning path
+            viewModel.Settings.SubscriptionTopic = "test/topic"; // silence the '#' subscription warning path (last-write-wins on StatusBarText)
+
+            viewModel.ConnectCommand.Execute(System.Reactive.Unit.Default).Subscribe();
+
+            _mqttServiceMock.Received(1).ConnectAsync();
+            Assert.Contains("isn't an Event Grid", viewModel.StatusBarText ?? string.Empty, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -325,4 +325,100 @@ public class SettingsViewModelTests
 
         Assert.Equal(8883, vm.Port);
     }
+
+    // --- Hostname normalization wired into the setter ---
+
+    [Fact]
+    public void SetHostname_WithEventGridHttpUrl_NormalizesToMqttFqdn_AndRaisesEvent()
+    {
+        var vm = new SettingsViewModel();
+        HostnameNormalizedEventArgs? captured = null;
+        vm.HostnameNormalized += (_, args) => captured = args;
+
+        vm.Hostname = "https://myns.northeurope-1.eventgrid.azure.net/api/events";
+
+        Assert.Equal("myns.northeurope-1.ts.eventgrid.azure.net", vm.Hostname);
+        Assert.NotNull(captured);
+        Assert.Equal("https://myns.northeurope-1.eventgrid.azure.net/api/events", captured!.Original);
+        Assert.Equal("myns.northeurope-1.ts.eventgrid.azure.net", captured.Cleaned);
+        Assert.Contains(captured.Notes, n => n.Contains("stripped 'https://'", System.StringComparison.Ordinal));
+        Assert.Contains(captured.Notes, n => n.Contains("Event Grid HTTP suffix", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SetHostname_WithInlinePort_ExtractsPortIntoPortProperty()
+    {
+        var vm = new SettingsViewModel { Port = 1883 };
+
+        vm.Hostname = "broker.example.com:8883";
+
+        Assert.Equal("broker.example.com", vm.Hostname);
+        Assert.Equal(8883, vm.Port);
+    }
+
+    [Fact]
+    public void SetHostname_WhenNormalizationMatchesExistingBackingField_StillRaisesPropertyChanged()
+    {
+        // Regression: when the user pastes a URL that normalizes to the value
+        // already stored on the backing field (e.g. hostname was loaded from
+        // settings.json as the MQTT FQDN, then user pastes the HTTP URL again),
+        // Hostname must still raise PropertyChanged. Otherwise the two-way
+        // bound TextBox keeps displaying the raw URL because it never sees a
+        // source update to replace its local buffer.
+        var vm = new SettingsViewModel();
+        vm.Hostname = "myns.northeurope-1.ts.eventgrid.azure.net"; // seed backing field
+
+        int changeNotifications = 0;
+        ((System.ComponentModel.INotifyPropertyChanged)vm).PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(SettingsViewModel.Hostname))
+            {
+                changeNotifications++;
+            }
+        };
+
+        // Assign a raw URL that normalizes to the SAME value already in the field.
+        vm.Hostname = "https://myns.northeurope-1.eventgrid.azure.net/api/events";
+
+        // Backing field ends up identical, but PropertyChanged still fires so
+        // the bound TextBox re-reads and drops its cached raw-URL text.
+        Assert.Equal("myns.northeurope-1.ts.eventgrid.azure.net", vm.Hostname);
+        Assert.True(changeNotifications >= 1, "PropertyChanged for Hostname must fire even when normalization results in an unchanged backing value.");
+    }
+
+    [Fact]
+    public void SetHostname_WithCleanValue_DoesNotRaiseEvent()
+    {
+        var vm = new SettingsViewModel();
+        int callCount = 0;
+        vm.HostnameNormalized += (_, _) => callCount++;
+
+        vm.Hostname = "broker.hivemq.com";
+
+        Assert.Equal("broker.hivemq.com", vm.Hostname);
+        Assert.Equal(0, callCount);
+    }
+
+    [Fact]
+    public void SelectingAzureAuthMode_BumpsTooLowKeepAliveAndSessionExpiry()
+    {
+        // Regression: users who typed sub-second Keep Alive / Session Expiry
+        // couldn't connect to Event Grid because it enforces minima. Switching
+        // to Azure interactively should nudge those values to broker-safe
+        // defaults without touching values that are already reasonable.
+        var vm = new SettingsViewModel
+        {
+            KeepAliveIntervalSeconds = 1,
+            SessionExpiryIntervalSeconds = 1,
+        };
+
+        // The auto-nudge for keep-alive / session-expiry lives in MainViewModel,
+        // not the setter — so this test only asserts what the setter guarantees:
+        // TLS/Port/Transport. Keep-alive/session-expiry nudge is covered in the
+        // DispatchCommand SetAuthMode Azure test.
+        vm.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+
+        Assert.True(vm.UseTls);
+        Assert.Equal(8883, vm.Port);
+    }
 }

--- a/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -191,4 +191,138 @@ public class SettingsViewModelTests
         vm.SelectedTransport = TransportProtocol.WebSocket;
         Assert.True(vm.IsWebSocketSelected);
     }
+
+    // --- Azure (Event Grid OAUTH2-JWT) tests ---
+
+    [Fact]
+    public void IsAzureAuthSelected_IsTrue_WhenAuthModeIsAzure()
+    {
+        var vm = new SettingsViewModel
+        {
+            SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure
+        };
+
+        Assert.True(vm.IsAzureAuthSelected);
+        Assert.False(vm.IsUsernamePasswordSelected);
+        Assert.False(vm.IsEnhancedAuthSelected);
+    }
+
+    [Fact]
+    public void SelectingAzureAuthMode_AutoEnablesTlsPort8883AndTcp()
+    {
+        var vm = new SettingsViewModel
+        {
+            UseTls = false,
+            Port = 1883,
+            SelectedTransport = TransportProtocol.WebSocket,
+        };
+
+        vm.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+
+        Assert.True(vm.UseTls);
+        Assert.Equal(8883, vm.Port);
+        Assert.Equal(TransportProtocol.Tcp, vm.SelectedTransport);
+    }
+
+    [Fact]
+    public void Into_SettingsData_HasAzureAuthenticationMode_WithCustomScope()
+    {
+        var vm = new SettingsViewModel
+        {
+            SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure,
+            AuthenticationScope = "api://my-app/.default"
+        };
+
+        var settingsData = vm.Into();
+
+        var azure = Assert.IsType<AzureAuthenticationMode>(settingsData.AuthMode);
+        Assert.Equal("api://my-app/.default", azure.Scope);
+        Assert.True(settingsData.UseTls);
+        Assert.Equal(8883, settingsData.Port);
+        Assert.Equal(TransportProtocol.Tcp, settingsData.Transport);
+    }
+
+    [Fact]
+    public void From_SettingsData_RoundtripsAzureAuthenticationMode()
+    {
+        var settingsData = new SettingsData(
+            "ns.region-1.ts.eventgrid.azure.net",
+            8883,
+            "my-client",
+            60,
+            true,
+            300,
+            new AzureAuthenticationMode("api://custom/.default"),
+            null,
+            null,
+            UseTls: true);
+        var vm = new SettingsViewModel();
+
+        vm.From(settingsData);
+
+        Assert.Equal(SettingsViewModel.AuthModeSelection.Azure, vm.SelectedAuthMode);
+        Assert.Equal("api://custom/.default", vm.AuthenticationScope);
+        Assert.True(vm.UseTls);
+        Assert.Equal(8883, vm.Port);
+        Assert.Equal(TransportProtocol.Tcp, vm.SelectedTransport);
+    }
+
+    [Fact]
+    public void From_SettingsData_AzureWithNullScope_LeavesScopeNull()
+    {
+        var settingsData = new SettingsData(
+            "ns.region-1.ts.eventgrid.azure.net",
+            8883,
+            null,
+            60,
+            true,
+            300,
+            new AzureAuthenticationMode(),
+            null,
+            null,
+            UseTls: true);
+        var vm = new SettingsViewModel();
+
+        vm.From(settingsData);
+
+        Assert.Equal(SettingsViewModel.AuthModeSelection.Azure, vm.SelectedAuthMode);
+        Assert.Null(vm.AuthenticationScope);
+    }
+
+    [Fact]
+    public void ApplyEnvironmentOverrides_AzureModeWithCustomPort_PreservesPort()
+    {
+        // Regression: the Azure auth-mode setter used to auto-force Port=8883 on
+        // every assignment, so an env-var-supplied non-default port (e.g. the
+        // mock Event Grid broker on 51883 inside Aspire) was silently overwritten.
+        var vm = new SettingsViewModel();
+        var overrides = new CrowsNestMqtt.BusinessLogic.Configuration.EnvironmentSettingsOverrides
+        {
+            Hostname = "127.0.0.1",
+            Port = 51883,
+            UseTls = true,
+            AuthMode = new AzureAuthenticationMode("https://eventgrid.azure.net/.default"),
+            HasOverrides = true,
+        };
+
+        vm.ApplyEnvironmentOverrides(overrides);
+
+        Assert.Equal(SettingsViewModel.AuthModeSelection.Azure, vm.SelectedAuthMode);
+        Assert.Equal("127.0.0.1", vm.Hostname);
+        Assert.Equal(51883, vm.Port);
+        Assert.True(vm.UseTls);
+    }
+
+    [Fact]
+    public void SelectingAzureAuthMode_Interactively_StillAutoAppliesDefaultPort()
+    {
+        // The auto-config remains helpful when the user picks Azure interactively
+        // via the settings pane or :setauthmode azure command (i.e. after the
+        // load phase completes).
+        var vm = new SettingsViewModel { Port = 1883 };
+
+        vm.SelectedAuthMode = SettingsViewModel.AuthModeSelection.Azure;
+
+        Assert.Equal(8883, vm.Port);
+    }
 }

--- a/tools/MockAzureEventGridBroker/DevCertificateFactory.cs
+++ b/tools/MockAzureEventGridBroker/DevCertificateFactory.cs
@@ -1,0 +1,51 @@
+namespace CrowsNestMqtt.MockAzureEventGridBroker;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+/// <summary>
+/// Generates ephemeral, self-signed X.509 certificates for the mock broker's TLS
+/// listener. The certificate exists only in memory and is regenerated on each
+/// process start. Clients must be configured to accept untrusted certificates —
+/// Crow's NestMQTT already does this by default.
+/// </summary>
+internal static class DevCertificateFactory
+{
+    /// <summary>
+    /// Creates a self-signed certificate and returns it as a PFX byte array so
+    /// callers can hand the raw bytes to APIs (like MQTTnet's
+    /// <c>WithEncryptionCertificate(byte[], …)</c>) without any private-key
+    /// export gymnastics on Windows.
+    /// </summary>
+    public static byte[] CreateSelfSignedPfxBytes(string hostname)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={hostname}, O=CrowsNestMqtt Mock Event Grid, OU=Local Development",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        // Allow TLS server usage.
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, // serverAuth
+                critical: false));
+
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName(hostname);
+        san.AddDnsName("localhost");
+        san.AddIpAddress(System.Net.IPAddress.Loopback);
+        request.CertificateExtensions.Add(san.Build());
+
+        var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var notAfter = notBefore.AddYears(1);
+        using var cert = request.CreateSelfSigned(notBefore, notAfter);
+
+        return cert.Export(X509ContentType.Pfx);
+    }
+}

--- a/tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj
+++ b/tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="MQTTnet.Server" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CrowsNestMqtt.MockBrokerTests" />
+  </ItemGroup>
 </Project>

--- a/tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj
+++ b/tools/MockAzureEventGridBroker/MockAzureEventGridBroker.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>CrowsNestMqtt.MockAzureEventGridBroker</RootNamespace>
+    <AssemblyName>CrowsNestMqtt.MockAzureEventGridBroker</AssemblyName>
+    <TargetFramework>$(AppTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MQTTnet" />
+    <PackageReference Include="MQTTnet.Server" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+</Project>

--- a/tools/MockAzureEventGridBroker/MockBroker.cs
+++ b/tools/MockAzureEventGridBroker/MockBroker.cs
@@ -1,0 +1,244 @@
+namespace CrowsNestMqtt.MockAzureEventGridBroker;
+
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.IdentityModel.Tokens.Jwt;
+using MQTTnet;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
+using MQTTnet.Server;
+
+/// <summary>
+/// In-process, single-use mock MQTT broker that emulates Azure Event Grid
+/// namespace enhanced authentication (<c>OAUTH2-JWT</c>). Accepts CONNECT
+/// packets whose AuthenticationMethod is <c>OAUTH2-JWT</c> and whose
+/// AuthenticationData contains a well-formed JWT. Signature and audience are
+/// NOT verified. Do not use in production or expose beyond localhost.
+///
+/// One instance binds exactly once; call <see cref="StartAsync"/>, then
+/// <see cref="StopAsync"/> or dispose. Tests should create a fresh instance
+/// per test to avoid MQTTnet server-lifecycle surprises.
+/// </summary>
+internal sealed class MockBroker : IAsyncDisposable
+{
+    internal const string ExpectedMethod = "OAUTH2-JWT";
+    internal const string ListeningStdoutPrefix = "MOCK_EG_LISTENING_ON=";
+
+    private readonly MockBrokerOptions _options;
+    private readonly TextWriter _log;
+
+    private MqttServer? _server;
+    private int _boundPort;
+    private bool _started;
+
+    public MockBroker(MockBrokerOptions options, TextWriter? log = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _log = log ?? Console.Out;
+    }
+
+    /// <summary>
+    /// Port the broker actually bound to. Zero before <see cref="StartAsync"/>
+    /// completes successfully.
+    /// </summary>
+    public int BoundPort => _boundPort;
+
+    /// <summary>
+    /// Starts the MQTT listener on <see cref="MockBrokerOptions.Host"/> and, if
+    /// specified, <see cref="MockBrokerOptions.Port"/> — otherwise an ephemeral
+    /// port is allocated. Returns the port that was actually bound so callers
+    /// can advertise it to clients.
+    /// </summary>
+    public async Task<int> StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_started)
+        {
+            throw new InvalidOperationException("MockBroker has already been started; create a new instance for a subsequent listener.");
+        }
+        _started = true;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var port = _options.Port ?? GetFreeTcpPort();
+        _boundPort = port;
+
+        Log(FormattableString.Invariant($"Starting mock Azure Event Grid broker on {_options.Host}:{port} (TLS={_options.UseTls})."));
+
+        var optionsBuilder = new MqttServerOptionsBuilder()
+            .WithPersistentSessions()
+            .WithKeepAlive();
+
+        if (_options.UseTls)
+        {
+            var pfxBytes = DevCertificateFactory.CreateSelfSignedPfxBytes(_options.Host);
+            var cert = X509CertificateLoader.LoadPkcs12(
+                pfxBytes,
+                password: null,
+                keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+
+            optionsBuilder = optionsBuilder
+                .WithEncryptedEndpoint()
+                .WithEncryptedEndpointBoundIPAddress(IPAddress.Parse(_options.Host))
+                .WithEncryptedEndpointPort(port)
+                .WithoutDefaultEndpoint()
+                .WithEncryptionCertificate(cert)
+                .WithEncryptionSslProtocol(System.Security.Authentication.SslProtocols.None);
+        }
+        else
+        {
+            optionsBuilder = optionsBuilder
+                .WithDefaultEndpoint()
+                .WithDefaultEndpointBoundIPAddress(IPAddress.Parse(_options.Host))
+                .WithDefaultEndpointPort(port);
+        }
+
+        var factory = new MqttServerFactory();
+        _server = factory.CreateMqttServer(optionsBuilder.Build());
+        _server.ValidatingConnectionAsync += HandleValidatingConnectionAsync;
+        _server.InterceptingInboundPacketAsync += HandleInboundPacketAsync;
+        _server.ClientConnectedAsync += HandleClientConnectedAsync;
+        _server.ClientDisconnectedAsync += HandleClientDisconnectedAsync;
+
+        await _server.StartAsync().ConfigureAwait(false);
+
+        // Bare stdout line consumed by Aspire and other orchestrators — must
+        // remain free of the timestamp/prefix that Log() adds.
+        _log.WriteLine(FormattableString.Invariant($"{ListeningStdoutPrefix}{_options.Host}:{port}"));
+        Log("Mock broker started. Waiting for connections.");
+        return port;
+    }
+
+    /// <summary>
+    /// Stops the underlying MQTT server if it is running. Safe to call multiple
+    /// times or before <see cref="StartAsync"/> — in either case the call is a
+    /// no-op.
+    /// </summary>
+    public async Task StopAsync()
+    {
+        if (_server is null)
+        {
+            return;
+        }
+
+        Log("Stopping mock broker...");
+        try
+        {
+            await _server.StopAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _server.Dispose();
+            _server = null;
+        }
+        Log("Mock broker stopped.");
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+    }
+
+    internal Task HandleValidatingConnectionAsync(ValidatingConnectionEventArgs args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (!string.Equals(args.AuthenticationMethod, ExpectedMethod, StringComparison.Ordinal))
+        {
+            args.ReasonCode = MqttConnectReasonCode.BadAuthenticationMethod;
+            args.ReasonString = FormattableString.Invariant(
+                $"Mock broker rejects CONNECT: expected AuthenticationMethod '{ExpectedMethod}', got '{args.AuthenticationMethod ?? "(null)"}'.");
+            Log(args.ReasonString);
+            return Task.CompletedTask;
+        }
+
+        if (args.AuthenticationData is null || args.AuthenticationData.Length == 0)
+        {
+            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
+            args.ReasonString = "Mock broker rejects CONNECT: AuthenticationData is empty.";
+            Log(args.ReasonString);
+            return Task.CompletedTask;
+        }
+
+        var tokenString = Encoding.UTF8.GetString(args.AuthenticationData);
+        try
+        {
+            var jwt = new JwtSecurityTokenHandler().ReadJwtToken(tokenString);
+            var sub = jwt.Subject ?? "(missing sub)";
+            var exp = jwt.ValidTo == default
+                ? "(no exp)"
+                : jwt.ValidTo.ToString("O", CultureInfo.InvariantCulture);
+            Log(FormattableString.Invariant(
+                $"Accepted CONNECT (method={ExpectedMethod}, client-id='{args.ClientId}', sub={sub}, exp={exp})."));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
+            args.ReasonString = FormattableString.Invariant(
+                $"Mock broker rejects CONNECT: AuthenticationData is not a valid JWT ({ex.GetType().Name}: {ex.Message}).");
+            Log(args.ReasonString);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal Task HandleInboundPacketAsync(InterceptingPacketEventArgs args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Packet is not MqttAuthPacket auth)
+        {
+            return Task.CompletedTask;
+        }
+
+        var tokenLen = auth.AuthenticationData?.Length ?? 0;
+        var summary = FormattableString.Invariant(
+            $"Received AUTH (method={auth.AuthenticationMethod}, reason={auth.ReasonCode}, data-bytes={tokenLen}, client-id='{args.ClientId}').");
+        try
+        {
+            if (auth.AuthenticationData is { Length: > 0 })
+            {
+                var jwt = new JwtSecurityTokenHandler().ReadJwtToken(
+                    Encoding.UTF8.GetString(auth.AuthenticationData));
+                summary += FormattableString.Invariant(
+                    $" JWT sub={jwt.Subject ?? "(missing)"}, exp={jwt.ValidTo.ToString("O", CultureInfo.InvariantCulture)}.");
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            summary += FormattableString.Invariant($" (JWT parse failed: {ex.Message})");
+        }
+        Log(summary);
+        return Task.CompletedTask;
+    }
+
+    private Task HandleClientConnectedAsync(ClientConnectedEventArgs args)
+    {
+        Log(FormattableString.Invariant($"Client connected: id='{args.ClientId}' endpoint={args.RemoteEndPoint}."));
+        return Task.CompletedTask;
+    }
+
+    private Task HandleClientDisconnectedAsync(ClientDisconnectedEventArgs args)
+    {
+        Log(FormattableString.Invariant($"Client disconnected: id='{args.ClientId}' type={args.DisconnectType}."));
+        return Task.CompletedTask;
+    }
+
+    internal static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private void Log(string message)
+    {
+        _log.WriteLine(FormattableString.Invariant(
+            $"[{DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}] [mock-eg-broker] {message}"));
+    }
+}

--- a/tools/MockAzureEventGridBroker/MockBrokerOptions.cs
+++ b/tools/MockAzureEventGridBroker/MockBrokerOptions.cs
@@ -1,0 +1,70 @@
+namespace CrowsNestMqtt.MockAzureEventGridBroker;
+
+using System.Globalization;
+using System.IO;
+
+/// <summary>
+/// Configuration for <see cref="MockBroker"/>. Encapsulates the host, TCP port,
+/// and TLS toggle so the same options can be produced either from environment
+/// variables (production entry point) or from test code.
+/// </summary>
+internal sealed record MockBrokerOptions(string Host, int? Port, bool UseTls)
+{
+    internal const string HostEnvVar = "MOCK_EG_HOST";
+    internal const string PortEnvVar = "MOCK_EG_PORT";
+    internal const string UseTlsEnvVar = "MOCK_EG_USE_TLS";
+
+    internal const string DefaultHost = "127.0.0.1";
+
+    /// <summary>
+    /// Builds a <see cref="MockBrokerOptions"/> instance from the supplied
+    /// environment-variable dictionary. Matches the historical Program.Main
+    /// behavior:
+    ///  * <c>MOCK_EG_HOST</c> — defaults to <c>127.0.0.1</c> when null/empty.
+    ///  * <c>MOCK_EG_PORT</c> — parsed as an integer; anything unparseable or
+    ///    missing leaves <see cref="Port"/> as <c>null</c>, signaling the caller
+    ///    to allocate an ephemeral port at bind time.
+    ///  * <c>MOCK_EG_USE_TLS</c> — defaults to <c>true</c> when null/empty;
+    ///    otherwise parsed via <see cref="bool.Parse(string)"/> (throws on
+    ///    invalid input to match the original behavior).
+    /// </summary>
+    public static MockBrokerOptions FromEnvironment(IReadOnlyDictionary<string, string?> environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var host = environment.TryGetValue(HostEnvVar, out var hostValue) && !string.IsNullOrEmpty(hostValue)
+            ? hostValue
+            : DefaultHost;
+
+        int? port = null;
+        if (environment.TryGetValue(PortEnvVar, out var portValue)
+            && int.TryParse(portValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPort))
+        {
+            port = parsedPort;
+        }
+
+        var useTls = true;
+        if (environment.TryGetValue(UseTlsEnvVar, out var useTlsValue) && !string.IsNullOrEmpty(useTlsValue))
+        {
+            useTls = bool.Parse(useTlsValue);
+        }
+
+        return new MockBrokerOptions(host, port, useTls);
+    }
+
+    /// <summary>
+    /// Convenience overload that snapshots the process environment. Used by
+    /// <see cref="Program.Main"/>; tests should prefer the dictionary overload
+    /// to keep them hermetic.
+    /// </summary>
+    public static MockBrokerOptions FromEnvironment()
+    {
+        var snapshot = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [HostEnvVar] = Environment.GetEnvironmentVariable(HostEnvVar),
+            [PortEnvVar] = Environment.GetEnvironmentVariable(PortEnvVar),
+            [UseTlsEnvVar] = Environment.GetEnvironmentVariable(UseTlsEnvVar),
+        };
+        return FromEnvironment(snapshot);
+    }
+}

--- a/tools/MockAzureEventGridBroker/Program.cs
+++ b/tools/MockAzureEventGridBroker/Program.cs
@@ -1,0 +1,196 @@
+namespace CrowsNestMqtt.MockAzureEventGridBroker;
+
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.IdentityModel.Tokens.Jwt;
+using MQTTnet;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
+using MQTTnet.Server;
+
+/// <summary>
+/// Development-only MQTT broker that emulates Azure Event Grid namespace enhanced
+/// authentication (<c>OAUTH2-JWT</c>). Accepts CONNECT packets whose
+/// AuthenticationMethod is <c>OAUTH2-JWT</c> and AuthenticationData contains a
+/// well-formed JWT. Signature and audience are NOT verified. Do not use in
+/// production or expose beyond localhost.
+///
+/// Configuration via env vars:
+///  <list type="bullet">
+///   <item><c>MOCK_EG_PORT</c> — TCP/TLS port to listen on (default: dynamic).</item>
+///   <item><c>MOCK_EG_HOST</c> — host to bind (default: 127.0.0.1).</item>
+///   <item><c>MOCK_EG_USE_TLS</c> — <c>true</c> to enable TLS with a self-signed cert (default: true).</item>
+///  </list>
+/// The chosen port is printed to stdout as <c>MOCK_EG_LISTENING_ON=&lt;host&gt;:&lt;port&gt;</c>.
+/// </summary>
+internal static class Program
+{
+    private const string ExpectedMethod = "OAUTH2-JWT";
+
+    internal static async Task Main()
+    {
+        var host = Environment.GetEnvironmentVariable("MOCK_EG_HOST") ?? "127.0.0.1";
+        var portEnv = Environment.GetEnvironmentVariable("MOCK_EG_PORT");
+        var useTlsEnv = Environment.GetEnvironmentVariable("MOCK_EG_USE_TLS");
+        var useTls = string.IsNullOrEmpty(useTlsEnv) || bool.Parse(useTlsEnv);
+
+        int port = int.TryParse(portEnv, out var p) ? p : GetFreeTcpPort();
+
+        Log($"Starting mock Azure Event Grid broker on {host}:{port} (TLS={useTls}).");
+
+        var optionsBuilder = new MqttServerOptionsBuilder()
+            .WithPersistentSessions()
+            .WithKeepAlive();
+
+        if (useTls)
+        {
+            // Materialize a self-signed X509 certificate whose private key is
+            // exportable and persisted — this is what MqttServer needs on Windows
+            // to complete the TLS handshake. Ephemeral private keys created by
+            // CertificateRequest.CreateSelfSigned aren't accessible during TLS.
+            var pfxBytes = DevCertificateFactory.CreateSelfSignedPfxBytes(host);
+            var cert = X509CertificateLoader.LoadPkcs12(
+                pfxBytes,
+                password: null,
+                keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+
+            optionsBuilder = optionsBuilder
+                .WithEncryptedEndpoint()
+                .WithEncryptedEndpointBoundIPAddress(IPAddress.Parse(host))
+                .WithEncryptedEndpointPort(port)
+                .WithoutDefaultEndpoint()
+                .WithEncryptionCertificate(cert)
+                .WithEncryptionSslProtocol(System.Security.Authentication.SslProtocols.None); // let OS choose
+        }
+        else
+        {
+            optionsBuilder = optionsBuilder
+                .WithDefaultEndpoint()
+                .WithDefaultEndpointBoundIPAddress(IPAddress.Parse(host))
+                .WithDefaultEndpointPort(port);
+        }
+
+        var factory = new MqttServerFactory();
+        using var server = factory.CreateMqttServer(optionsBuilder.Build());
+
+        server.ValidatingConnectionAsync += HandleValidatingConnectionAsync;
+        server.InterceptingInboundPacketAsync += HandleInboundPacketAsync;
+        server.ClientConnectedAsync += args =>
+        {
+            Log($"Client connected: id='{args.ClientId}' endpoint={args.RemoteEndPoint}.");
+            return Task.CompletedTask;
+        };
+        server.ClientDisconnectedAsync += args =>
+        {
+            Log($"Client disconnected: id='{args.ClientId}' type={args.DisconnectType}.");
+            return Task.CompletedTask;
+        };
+
+        await server.StartAsync().ConfigureAwait(false);
+
+        // Publish the effective endpoint so Aspire / test harnesses can discover it.
+        Console.WriteLine($"MOCK_EG_LISTENING_ON={host}:{port}");
+        Log("Mock broker started. Waiting for connections. Press Ctrl+C to stop.");
+
+        var stopTcs = new TaskCompletionSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            stopTcs.TrySetResult();
+        };
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => stopTcs.TrySetResult();
+
+        await stopTcs.Task.ConfigureAwait(false);
+
+        Log("Stopping mock broker...");
+        await server.StopAsync().ConfigureAwait(false);
+        Log("Mock broker stopped.");
+    }
+
+    private static Task HandleValidatingConnectionAsync(ValidatingConnectionEventArgs args)
+    {
+        if (!string.Equals(args.AuthenticationMethod, ExpectedMethod, StringComparison.Ordinal))
+        {
+            args.ReasonCode = MqttConnectReasonCode.BadAuthenticationMethod;
+            args.ReasonString =
+                $"Mock broker rejects CONNECT: expected AuthenticationMethod '{ExpectedMethod}', got '{args.AuthenticationMethod ?? "(null)"}'.";
+            Log(args.ReasonString);
+            return Task.CompletedTask;
+        }
+
+        if (args.AuthenticationData is null || args.AuthenticationData.Length == 0)
+        {
+            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
+            args.ReasonString = "Mock broker rejects CONNECT: AuthenticationData is empty.";
+            Log(args.ReasonString);
+            return Task.CompletedTask;
+        }
+
+        // The token must be a syntactically valid JWT. Signature is intentionally NOT verified.
+        var tokenString = Encoding.UTF8.GetString(args.AuthenticationData);
+        try
+        {
+            var jwt = new JwtSecurityTokenHandler().ReadJwtToken(tokenString);
+            var sub = jwt.Subject ?? "(missing sub)";
+            var exp = jwt.ValidTo == default ? "(no exp)" : jwt.ValidTo.ToString("O");
+            Log($"Accepted CONNECT (method={ExpectedMethod}, client-id='{args.ClientId}', sub={sub}, exp={exp}).");
+        }
+        catch (Exception ex)
+        {
+            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
+            args.ReasonString = $"Mock broker rejects CONNECT: AuthenticationData is not a valid JWT ({ex.GetType().Name}: {ex.Message}).";
+            Log(args.ReasonString);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Task HandleInboundPacketAsync(InterceptingPacketEventArgs args)
+    {
+        // MQTT v5 client-initiated re-authentication surfaces as an AUTH packet on
+        // an already-connected session. Log the new token for observability. We
+        // don't need to send an AUTH response — Azure Event Grid re-auth is a
+        // one-shot notification from the client.
+        if (args.Packet is MqttAuthPacket auth)
+        {
+            var tokenLen = auth.AuthenticationData?.Length ?? 0;
+            var reason = auth.ReasonCode;
+            var summary = $"Received AUTH (method={auth.AuthenticationMethod}, reason={reason}, data-bytes={tokenLen}, client-id='{args.ClientId}').";
+            try
+            {
+                if (auth.AuthenticationData is { Length: > 0 })
+                {
+                    var jwt = new JwtSecurityTokenHandler().ReadJwtToken(
+                        Encoding.UTF8.GetString(auth.AuthenticationData));
+                    summary += $" JWT sub={jwt.Subject ?? "(missing)"}, exp={jwt.ValidTo:O}.";
+                }
+            }
+            catch (Exception ex)
+            {
+                summary += $" (JWT parse failed: {ex.Message})";
+            }
+            Log(summary);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        // Bind an ephemeral socket on the loopback and read the assigned port. The
+        // socket is closed immediately; there's an inherent tiny race window before
+        // MqttServer binds, but it's acceptable for a dev-only broker.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static void Log(string message)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow:O}] [mock-eg-broker] {message}");
+    }
+}

--- a/tools/MockAzureEventGridBroker/Program.cs
+++ b/tools/MockAzureEventGridBroker/Program.cs
@@ -1,15 +1,5 @@
 namespace CrowsNestMqtt.MockAzureEventGridBroker;
 
-using System.Net;
-using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.IdentityModel.Tokens.Jwt;
-using MQTTnet;
-using MQTTnet.Packets;
-using MQTTnet.Protocol;
-using MQTTnet.Server;
-
 /// <summary>
 /// Development-only MQTT broker that emulates Azure Event Grid namespace enhanced
 /// authentication (<c>OAUTH2-JWT</c>). Accepts CONNECT packets whose
@@ -24,75 +14,18 @@ using MQTTnet.Server;
 ///   <item><c>MOCK_EG_USE_TLS</c> — <c>true</c> to enable TLS with a self-signed cert (default: true).</item>
 ///  </list>
 /// The chosen port is printed to stdout as <c>MOCK_EG_LISTENING_ON=&lt;host&gt;:&lt;port&gt;</c>.
+/// The heavy lifting lives in <see cref="MockBroker"/> — <see cref="Program"/> is
+/// a thin process-lifetime wrapper so both the CLI entry point and the in-process
+/// tests share the same implementation.
 /// </summary>
 internal static class Program
 {
-    private const string ExpectedMethod = "OAUTH2-JWT";
-
     internal static async Task Main()
     {
-        var host = Environment.GetEnvironmentVariable("MOCK_EG_HOST") ?? "127.0.0.1";
-        var portEnv = Environment.GetEnvironmentVariable("MOCK_EG_PORT");
-        var useTlsEnv = Environment.GetEnvironmentVariable("MOCK_EG_USE_TLS");
-        var useTls = string.IsNullOrEmpty(useTlsEnv) || bool.Parse(useTlsEnv);
+        var options = MockBrokerOptions.FromEnvironment();
+        await using var broker = new MockBroker(options);
 
-        int port = int.TryParse(portEnv, out var p) ? p : GetFreeTcpPort();
-
-        Log($"Starting mock Azure Event Grid broker on {host}:{port} (TLS={useTls}).");
-
-        var optionsBuilder = new MqttServerOptionsBuilder()
-            .WithPersistentSessions()
-            .WithKeepAlive();
-
-        if (useTls)
-        {
-            // Materialize a self-signed X509 certificate whose private key is
-            // exportable and persisted — this is what MqttServer needs on Windows
-            // to complete the TLS handshake. Ephemeral private keys created by
-            // CertificateRequest.CreateSelfSigned aren't accessible during TLS.
-            var pfxBytes = DevCertificateFactory.CreateSelfSignedPfxBytes(host);
-            var cert = X509CertificateLoader.LoadPkcs12(
-                pfxBytes,
-                password: null,
-                keyStorageFlags: X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
-
-            optionsBuilder = optionsBuilder
-                .WithEncryptedEndpoint()
-                .WithEncryptedEndpointBoundIPAddress(IPAddress.Parse(host))
-                .WithEncryptedEndpointPort(port)
-                .WithoutDefaultEndpoint()
-                .WithEncryptionCertificate(cert)
-                .WithEncryptionSslProtocol(System.Security.Authentication.SslProtocols.None); // let OS choose
-        }
-        else
-        {
-            optionsBuilder = optionsBuilder
-                .WithDefaultEndpoint()
-                .WithDefaultEndpointBoundIPAddress(IPAddress.Parse(host))
-                .WithDefaultEndpointPort(port);
-        }
-
-        var factory = new MqttServerFactory();
-        using var server = factory.CreateMqttServer(optionsBuilder.Build());
-
-        server.ValidatingConnectionAsync += HandleValidatingConnectionAsync;
-        server.InterceptingInboundPacketAsync += HandleInboundPacketAsync;
-        server.ClientConnectedAsync += args =>
-        {
-            Log($"Client connected: id='{args.ClientId}' endpoint={args.RemoteEndPoint}.");
-            return Task.CompletedTask;
-        };
-        server.ClientDisconnectedAsync += args =>
-        {
-            Log($"Client disconnected: id='{args.ClientId}' type={args.DisconnectType}.");
-            return Task.CompletedTask;
-        };
-
-        await server.StartAsync().ConfigureAwait(false);
-
-        // Publish the effective endpoint so Aspire / test harnesses can discover it.
-        Console.WriteLine($"MOCK_EG_LISTENING_ON={host}:{port}");
-        Log("Mock broker started. Waiting for connections. Press Ctrl+C to stop.");
+        await broker.StartAsync().ConfigureAwait(false);
 
         var stopTcs = new TaskCompletionSource();
         Console.CancelKeyPress += (_, e) =>
@@ -103,94 +36,6 @@ internal static class Program
         AppDomain.CurrentDomain.ProcessExit += (_, _) => stopTcs.TrySetResult();
 
         await stopTcs.Task.ConfigureAwait(false);
-
-        Log("Stopping mock broker...");
-        await server.StopAsync().ConfigureAwait(false);
-        Log("Mock broker stopped.");
-    }
-
-    private static Task HandleValidatingConnectionAsync(ValidatingConnectionEventArgs args)
-    {
-        if (!string.Equals(args.AuthenticationMethod, ExpectedMethod, StringComparison.Ordinal))
-        {
-            args.ReasonCode = MqttConnectReasonCode.BadAuthenticationMethod;
-            args.ReasonString =
-                $"Mock broker rejects CONNECT: expected AuthenticationMethod '{ExpectedMethod}', got '{args.AuthenticationMethod ?? "(null)"}'.";
-            Log(args.ReasonString);
-            return Task.CompletedTask;
-        }
-
-        if (args.AuthenticationData is null || args.AuthenticationData.Length == 0)
-        {
-            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
-            args.ReasonString = "Mock broker rejects CONNECT: AuthenticationData is empty.";
-            Log(args.ReasonString);
-            return Task.CompletedTask;
-        }
-
-        // The token must be a syntactically valid JWT. Signature is intentionally NOT verified.
-        var tokenString = Encoding.UTF8.GetString(args.AuthenticationData);
-        try
-        {
-            var jwt = new JwtSecurityTokenHandler().ReadJwtToken(tokenString);
-            var sub = jwt.Subject ?? "(missing sub)";
-            var exp = jwt.ValidTo == default ? "(no exp)" : jwt.ValidTo.ToString("O");
-            Log($"Accepted CONNECT (method={ExpectedMethod}, client-id='{args.ClientId}', sub={sub}, exp={exp}).");
-        }
-        catch (Exception ex)
-        {
-            args.ReasonCode = MqttConnectReasonCode.NotAuthorized;
-            args.ReasonString = $"Mock broker rejects CONNECT: AuthenticationData is not a valid JWT ({ex.GetType().Name}: {ex.Message}).";
-            Log(args.ReasonString);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    private static Task HandleInboundPacketAsync(InterceptingPacketEventArgs args)
-    {
-        // MQTT v5 client-initiated re-authentication surfaces as an AUTH packet on
-        // an already-connected session. Log the new token for observability. We
-        // don't need to send an AUTH response — Azure Event Grid re-auth is a
-        // one-shot notification from the client.
-        if (args.Packet is MqttAuthPacket auth)
-        {
-            var tokenLen = auth.AuthenticationData?.Length ?? 0;
-            var reason = auth.ReasonCode;
-            var summary = $"Received AUTH (method={auth.AuthenticationMethod}, reason={reason}, data-bytes={tokenLen}, client-id='{args.ClientId}').";
-            try
-            {
-                if (auth.AuthenticationData is { Length: > 0 })
-                {
-                    var jwt = new JwtSecurityTokenHandler().ReadJwtToken(
-                        Encoding.UTF8.GetString(auth.AuthenticationData));
-                    summary += $" JWT sub={jwt.Subject ?? "(missing)"}, exp={jwt.ValidTo:O}.";
-                }
-            }
-            catch (Exception ex)
-            {
-                summary += $" (JWT parse failed: {ex.Message})";
-            }
-            Log(summary);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    private static int GetFreeTcpPort()
-    {
-        // Bind an ephemeral socket on the loopback and read the assigned port. The
-        // socket is closed immediately; there's an inherent tiny race window before
-        // MqttServer binds, but it's acceptable for a dev-only broker.
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    private static void Log(string message)
-    {
-        Console.WriteLine($"[{DateTime.UtcNow:O}] [mock-eg-broker] {message}");
+        await broker.StopAsync().ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
This pull request adds first-class support for connecting to Azure Event Grid MQTT brokers using Entra ID (Azure AD) tokens, including seamless local emulation for development and testing. It introduces a new `azure` authentication mode, updates configuration and command handling to support Azure-specific settings, and provides comprehensive documentation and test coverage for the new functionality. The Aspire AppHost is enhanced to launch a mock Azure Event Grid broker and synthesize JWTs for local integration tests.

**Azure Event Grid support and emulation:**

* Added a new `azure` authentication mode to the application, enabling connections to Azure Event Grid namespaces using Entra ID tokens acquired via `Azure.Identity.DefaultAzureCredential`. This includes automatic token refresh, Azure-specific connection settings (TLS, port 8883), and custom OAuth scope support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122-R129) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R408) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-R459) [[4]](diffhunk://#diff-9ec3d416716030bbbda9a4f00d2b3204325c81c1d2a3a8b6c859ec19848addedR12)
* Updated the Aspire AppHost (`src/AppHost/Program.cs`) to launch a local mock Azure Event Grid broker for development/testing, synthesize JWTs for authentication, and configure a fourth Crow's Nest instance to exercise the Azure code path. [[1]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666R67-R127) [[2]](diffhunk://#diff-fd1eac5064bda6e2310e0ba96694f4249e18d700f3c8fc10a9cbd8e59efe7666R138-R167) [[3]](diffhunk://#diff-b567b7f5c14c731999a08ea97ea0b852616628d6f0bff81e1bc3761f1b05564cR12-R21) [[4]](diffhunk://#diff-d8e7c8125c1eb69cb1880cb9aba7f03b03f6f037b792513ecc9998d117f99a56R7-R9)

**Configuration and commands:**

* Extended the configuration system to support Azure-specific environment variables (e.g., `CROWSNEST__AUTH_MODE=azure`, `CROWSNEST__AUTH_SCOPE`, `CROWSNEST__AZURE_TOKEN_OVERRIDE`) and documented their usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-R459) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R31) [[3]](diffhunk://#diff-1d6c69ad1bc39b239dd8cd8549da7d084cdc4c812a1759695ec36214448a5ce5R12)
* Added new commands for Azure and MQTT v5 features: `:setauthmode azure`, `:setauthscope`, `:setclientid`, `:setsubscription`, and `:azurewhoami`, with clear documentation and updated command handling enums. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R208) [[2]](diffhunk://#diff-9f308a36c9b5c2964f653ec7b79ad362e18a53801aea7d8f915677932b98e01aR56-R57) [[3]](diffhunk://#diff-9f308a36c9b5c2964f653ec7b79ad362e18a53801aea7d8f915677932b98e01aR66-R71)

**Documentation:**

* Major expansion of the `README.md` to cover Azure Event Grid MQTT integration, including setup, troubleshooting, local emulation, and automated test instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122-R129) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R208) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R408) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-R459)

These changes make it much easier to develop, test, and use Crow's Nest MQTT with Azure Event Grid, both locally and in real Azure environments.