### PR TITLE
Add WebSocket proxy support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,14 @@
             "name": "C#: Crow'S NestMQTT Debug",
             "type": "dotnet",
             "request": "launch",
-            "projectPath": "${workspaceFolder}/src/MainApp/CrowsNestMqtt.App.csproj"
+            "projectPath": "${workspaceFolder}/src/MainApp/CrowsNestMqtt.App.csproj",
+            "preLaunchTask": "build"
         },
         {
             "name": "C#: Aspire AppHost (http)",
             "type": "coreclr",
             "request": "launch",
+            "preLaunchTask": "build",
             "program": "dotnet",
             "cwd": "${workspaceFolder}",
             "args": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,9 @@
                 // Ask dotnet build to generate full paths for file names.
                 "/property:GenerateFullPaths=true",
                 // Do not generate summary otherwise it leads to duplicate errors in Problems panel
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                // Avoid stale 0-byte DLLs from interrupted post-compile weavers (e.g. Fody)
+                "--no-incremental"
             ],
             "group": {
                 "kind": "build",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="3.0.23.1" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <PackageVersion Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <PackageVersion Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageVersion Include="MQTTnet.AspNetCore" Version="5.1.0.1559" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ xattr -dr com.apple.quarantine /Applications/CrowsNestMQTT.app
     * Strikethrough and dimmed text in message history for expired messages
     * Yellow warning icon in metadata view for the expiry field
 * Supports TLS connection to MQTT Broker 🔐
-* Supports WebSocket transport (ws:// and wss://) 🌐
+* Supports WebSocket transport (ws:// and wss://), including HTTP(S) forward proxies 🌐
 * Can handle huge amount of MQTT messages 
 * Allows filtering of MQTT topics by pattern 🗃️
 * Allows searching of pattern within MQTT message payloads 🔍
@@ -107,6 +107,8 @@ Configure how the client connects to your MQTT broker:
 - **Hostname**: The broker address (default: `localhost`).
 - **Port**: The broker port (default: `1883`).
 - **Use TLS**: Enable to connect to the broker using TLS encryption. If enabled, the client will allow untrusted certificates and ignore certificate chain and revocation errors. You can also set this via the `:setusetls <true|false>` command.
+- **Transport / WS Path**: Select WebSocket transport and configure its broker path (default: `/mqtt`).
+- **WS Proxy / Proxy User / Proxy Password**: Optional HTTP(S) forward proxy settings used only for WebSocket transport.
 - **Client ID**: Optional identifier for the client. If left blank, one is generated.
 - **Keep Alive Interval**: Time in seconds between keep-alive pings (default: `60`).
 - **Clean Session**: If enabled, the broker does not retain session data after disconnect.
@@ -210,6 +212,7 @@ Crow's Nest MQTT provides a command interface (likely accessible via a dedicated
 *   `:setsubscription [<topic-filter>]` - Set the MQTT topic filter for the client's initial subscription. Defaults to `#`. Azure Event Grid rejects `#`; use a filter that matches your Topic Space template (e.g. `sensors/#`). Omit the argument to reset to `#`.
 *   `:azurewhoami` - Print the identity (`upn`, `oid`, `name`, `appid`, `tenant`) that `DefaultAzureCredential` will use for Azure Event Grid. Use the values it prints to configure the `authenticationName` on the Event Grid Client resource.
 *   `:setusetls <true|false>` - Set whether to use TLS for the MQTT connection. When set to `true`, the client will connect using TLS, allow untrusted certificates, and ignore certificate errors.
+*   `:setproxy [<http[s]://host:port> [<username> [<password>]]]` - Configure the forward proxy used for WebSocket transport. Omit all arguments to clear it, and reconnect after changing it. A dedicated command is used instead of extending `:connect` because proxy configuration is transport-level state that should persist across broker reconnects and remain separate from MQTT broker credentials.
 *   `:publish [topic] [@file|text]` - Open the publish window. Optionally pre-fill the topic (defaults to the selected topic) and payload from a file (`@path/to/file`) or inline text. The publish window is non-modal and supports all MQTT V5 properties.
 *   `:stats` - Open a non-modal window showing per-topic statistics (message count, total payload size, average payload size, mean time between messages) for every topic that has received a message. The counters are lifetime totals — they are not affected by ring-buffer eviction and only reset on `:clear`. The table is sortable, updates once per second, and can be copied as a GitHub-flavored Markdown table via the *Copy as Markdown* button (or `Ctrl+C`).
 *   `[search_term]` - Any text entered without a `:` prefix is treated as a search term to filter messages.
@@ -424,6 +427,13 @@ When an Aspire endpoint environment variable is detected, the application:
 3. Automatically connects to the broker on startup
 4. Persists the overridden values to `settings.json` so other tools can use them
 
+The repository AppHost also starts an `ubuntu/squid` forward proxy and a
+`crows-nest-mqtt-ws-proxy` application instance. That instance connects to the
+EMQX WebSocket listener through Squid, so proxy behavior can be exercised from
+the Aspire dashboard without additional setup. The AppHost mounts
+`src/AppHost/squid/crowsnest.conf`, which permits HTTP CONNECT tunneling to the
+EMQX WebSocket listener on port `8083`.
+
 ```csharp
   // ...
   var mqttViewerWorkingDirectory = @"S:\upertools\CrowsNestMqtt";
@@ -464,6 +474,9 @@ This is useful for:
 | `CROWSNEST__USE_TLS` | Enable TLS encryption | bool | `true` |
 | `CROWSNEST__TRANSPORT` | Transport protocol | enum | `Tcp`, `WebSocket` |
 | `CROWSNEST__WEBSOCKET_PATH` | WebSocket path (when TRANSPORT=WebSocket) | string | `/mqtt` |
+| `CROWSNEST__WEBSOCKET_PROXY_ADDRESS` | HTTP(S) forward proxy used for WebSocket transport | URI | `http://proxy.example.com:3128` |
+| `CROWSNEST__WEBSOCKET_PROXY_USERNAME` | Optional proxy username | string | `proxy-user` |
+| `CROWSNEST__WEBSOCKET_PROXY_PASSWORD` | Optional proxy password | string | `proxy-password` |
 | `CROWSNEST__SUBSCRIPTION_QOS` | Subscription QoS level (0, 1, or 2) | int | `1` |
 | `CROWSNEST__EXPORT_FORMAT` | Default export format | enum | `json`, `txt` |
 | `CROWSNEST__EXPORT_PATH` | Default export file path | string | `/tmp/exports` |
@@ -504,6 +517,20 @@ export CROWSNEST__PORT=8084
 export CROWSNEST__TRANSPORT=WebSocket
 export CROWSNEST__USE_TLS=true
 export CROWSNEST__WEBSOCKET_PATH=/mqtt
+```
+
+### Example: WebSocket Through a Forward Proxy
+
+```bash
+export CROWSNEST__HOSTNAME=broker.example.com
+export CROWSNEST__PORT=8083
+export CROWSNEST__TRANSPORT=WebSocket
+export CROWSNEST__WEBSOCKET_PATH=/mqtt
+export CROWSNEST__WEBSOCKET_PROXY_ADDRESS=http://proxy.example.com:3128
+
+# Optional proxy authentication:
+export CROWSNEST__WEBSOCKET_PROXY_USERNAME=proxy-user
+export CROWSNEST__WEBSOCKET_PROXY_PASSWORD=proxy-password
 ```
 
 ### Example: Manual Configuration

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -18,12 +18,19 @@ var mqttBroker = builder.AddContainer("mqtt", "emqx/emqx", "latest")
     .WithEnvironment("EMQX_LISTENERS__TCP__DEFAULT__BIND", "0.0.0.0:1883")
     .WithEnvironment("EMQX_LISTENERS__WS__DEFAULT__BIND", "0.0.0.0:8083")
     .WithEnvironment("EMQX_LISTENERS__SSL__DEFAULT__BIND", "0.0.0.0:8883")
-    .WithEnvironment("EMQX_MQTT__MAX_PACKET_SIZE", "10MB");
+    .WithEnvironment("EMQX_MQTT__MAX_PACKET_SIZE", "10MB")
+    .WithHttpHealthCheck("/status", endpointName: "dashboard");
 
 // Get the MQTT endpoints for passing to the client applications
 var mqttEndpoint = mqttBroker.GetEndpoint("mqtt");
 var wsEndpoint = mqttBroker.GetEndpoint("ws");
 var mqttsEndpoint = mqttBroker.GetEndpoint("mqtts");
+
+// Forward proxy used to exercise WebSocket proxy configuration locally.
+var webSocketProxy = builder.AddContainer("websocket-proxy", "ubuntu/squid", "latest")
+    .WithBindMount("./squid/crowsnest.conf", "/etc/squid/conf.d/crowsnest.conf", isReadOnly: true)
+    .WithEndpoint(targetPort: 3128, name: "http", scheme: "http");
+var webSocketProxyEndpoint = webSocketProxy.GetEndpoint("http");
 
 // Shared settings for all CrowsNestMqtt instances
 var sharedEnvVars = (IResourceBuilder<ProjectResource> rb) => rb
@@ -54,6 +61,25 @@ var wsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt
     .WithEnvironment("CROWSNEST__TRANSPORT", "WebSocket")
     .WithEnvironment("CROWSNEST__WEBSOCKET_PATH", "/mqtt");
 sharedEnvVars(wsInstance);
+
+// Add a WebSocket instance that reaches the broker through the Squid forward proxy.
+// The broker hostname is its container resource name because Squid resolves the
+// destination inside the Aspire container network.
+var proxiedWsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt-ws-proxy")
+    .WithReference(wsEndpoint)
+    .WithReference(webSocketProxyEndpoint)
+    .WaitFor(mqttBroker)
+    .WaitFor(webSocketProxy)
+    .WithEnvironment("CROWSNEST__HOSTNAME", "mqtt")
+    .WithEnvironment("CROWSNEST__PORT", "8083")
+    .WithEnvironment("CROWSNEST__USE_TLS", "false")
+    .WithEnvironment("CROWSNEST__TRANSPORT", "WebSocket")
+    .WithEnvironment("CROWSNEST__WEBSOCKET_PATH", "/mqtt")
+    .WithEnvironment(
+        "CROWSNEST__WEBSOCKET_PROXY_ADDRESS",
+        ReferenceExpression.Create(
+            $"http://{webSocketProxyEndpoint.Property(EndpointProperty.Host)}:{webSocketProxyEndpoint.Property(EndpointProperty.Port)}"));
+sharedEnvVars(proxiedWsInstance);
 
 // Add a third CrowsNestMqtt instance that connects via TLS
 var tlsInstance = builder.AddProject<Projects.CrowsNestMqtt_App>("crows-nest-mqtt-tls")
@@ -164,4 +190,3 @@ static string CreateDevJwt()
 
     return handler.WriteToken(token);
 }
-

--- a/src/AppHost/squid/crowsnest.conf
+++ b/src/AppHost/squid/crowsnest.conf
@@ -1,0 +1,7 @@
+# MQTTnet uses HTTP CONNECT for WebSocket proxy connections, including ws://.
+# Extend Ubuntu Squid's defaults so Aspire clients can tunnel to EMQX.
+acl Safe_ports port 8083
+acl SSL_ports port 8083
+
+# Aspire project processes reach the container through the Docker bridge gateway.
+http_access allow localnet CONNECT SSL_ports

--- a/src/BusinessLogic/Commands/CommandType.cs
+++ b/src/BusinessLogic/Commands/CommandType.cs
@@ -57,6 +57,8 @@ public enum CommandType
     SetAuthScope,
     /// <summary> Set the MQTT TLS usage flag. </summary>
     SetUseTls,
+    /// <summary> Configure or clear the HTTP proxy used for WebSocket transport. </summary>
+    SetWebSocketProxy,
     /// <summary> Delete retained messages from a topic and its subtopics. </summary>
     DeleteTopic,
     /// <summary> Navigate to the response message for the currently selected request message. </summary>

--- a/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
+++ b/src/BusinessLogic/Configutation/EnvironmentSettingsOverrides.cs
@@ -34,6 +34,9 @@ public sealed record EnvironmentSettingsOverrides
     public IList<TopicBufferLimit>? TopicSpecificBufferLimits { get; init; }
     public TransportProtocol? Transport { get; init; }
     public string? WebSocketPath { get; init; }
+    public string? WebSocketProxyAddress { get; init; }
+    public string? WebSocketProxyUsername { get; init; }
+    public string? WebSocketProxyPassword { get; init; }
 
     /// <summary>
     /// Whether any environment variable overrides were detected.
@@ -92,6 +95,9 @@ public sealed record EnvironmentSettingsOverrides
         var authMode = ReadAuthMode();
         var envTransport = ReadTransport("TRANSPORT");
         var envWebSocketPath = ReadString("WEBSOCKET_PATH");
+        var webSocketProxyAddress = ReadString("WEBSOCKET_PROXY_ADDRESS");
+        var webSocketProxyUsername = ReadString("WEBSOCKET_PROXY_USERNAME");
+        var webSocketProxyPassword = ReadString("WEBSOCKET_PROXY_PASSWORD");
 
         // Explicit CROWSNEST__ hostname/port override Aspire-derived values
         if (envHostname != null) hostname = envHostname;
@@ -111,7 +117,9 @@ public sealed record EnvironmentSettingsOverrides
             || maxTopicLimit.HasValue || parallelismDegree.HasValue
             || timeoutSeconds.HasValue || defaultBufferSize.HasValue
             || topicLimits != null || authMode != null
-            || transport.HasValue || webSocketPath != null;
+            || transport.HasValue || webSocketPath != null
+            || webSocketProxyAddress != null || webSocketProxyUsername != null
+            || webSocketProxyPassword != null;
 
         if (hasAny)
         {
@@ -138,6 +146,9 @@ public sealed record EnvironmentSettingsOverrides
             TopicSpecificBufferLimits = topicLimits,
             Transport = transport,
             WebSocketPath = webSocketPath,
+            WebSocketProxyAddress = webSocketProxyAddress,
+            WebSocketProxyUsername = webSocketProxyUsername,
+            WebSocketProxyPassword = webSocketProxyPassword,
             HasOverrides = hasAny,
             IsAspireEnvironment = isAspire
         };

--- a/src/BusinessLogic/Configutation/SettingsData.cs
+++ b/src/BusinessLogic/Configutation/SettingsData.cs
@@ -20,7 +20,10 @@ public record SettingsData(
     int SubscriptionQoS = 1,
     TransportProtocol Transport = TransportProtocol.Tcp,
     string? WebSocketPath = null,
-    string SubscriptionTopic = "#")
+    string SubscriptionTopic = "#",
+    string? WebSocketProxyAddress = null,
+    string? WebSocketProxyUsername = null,
+    string? WebSocketProxyPassword = null)
 {
     public IList<TopicBufferLimit> TopicSpecificBufferLimits { get; init; } = new List<TopicBufferLimit>();
     /// <summary>

--- a/src/BusinessLogic/MqttConnectionSettings.cs
+++ b/src/BusinessLogic/MqttConnectionSettings.cs
@@ -34,6 +34,12 @@ public class MqttConnectionSettings
     /// </summary>
     public string? WebSocketPath { get; set; }
     /// <summary>
+    /// HTTP or HTTPS forward proxy used for WebSocket connections.
+    /// </summary>
+    public string? WebSocketProxyAddress { get; set; }
+    public string? WebSocketProxyUsername { get; set; }
+    public string? WebSocketProxyPassword { get; set; }
+    /// <summary>
     /// QoS level for the wildcard subscription. Default is 1 (AtLeastOnce).
     /// Set to 2 (ExactlyOnce) if you need to receive QoS 2 messages without downgrade.
     /// Higher QoS reduces maximum message throughput.

--- a/src/BusinessLogic/MqttEngine.cs
+++ b/src/BusinessLogic/MqttEngine.cs
@@ -252,7 +252,34 @@ private MqttClientOptions? _currentOptions;
             var scheme = useTls ? "wss" : "ws";
             var path = string.IsNullOrWhiteSpace(_settings.WebSocketPath) ? "/mqtt" : _settings.WebSocketPath;
             var uri = $"{scheme}://{_settings.Hostname}:{_settings.Port}{path}";
-            builder.WithWebSocketServer(o => o.WithUri(uri));
+            builder.WithWebSocketServer(o =>
+            {
+                o.WithUri(uri);
+
+                if (!string.IsNullOrWhiteSpace(_settings.WebSocketProxyAddress))
+                {
+                    if (!Uri.TryCreate(_settings.WebSocketProxyAddress, UriKind.Absolute, out var proxyUri)
+                        || string.IsNullOrWhiteSpace(proxyUri.Host)
+                        || proxyUri.Scheme is not ("http" or "https"))
+                    {
+                        throw new InvalidOperationException(
+                            "WebSocket proxy address must be an absolute HTTP or HTTPS URI.");
+                    }
+
+                    o.WithProxyOptions(proxy =>
+                    {
+                        proxy.WithAddress(_settings.WebSocketProxyAddress);
+                        if (!string.IsNullOrWhiteSpace(_settings.WebSocketProxyUsername))
+                        {
+                            proxy.WithUsername(_settings.WebSocketProxyUsername);
+                        }
+                        if (_settings.WebSocketProxyPassword != null)
+                        {
+                            proxy.WithPassword(_settings.WebSocketProxyPassword);
+                        }
+                    });
+                }
+            });
         }
         else
         {

--- a/src/BusinessLogic/Services/CommandParserService.cs
+++ b/src/BusinessLogic/Services/CommandParserService.cs
@@ -384,6 +384,23 @@ public class CommandParserService : ICommandParserService
                 }
                 return CommandResult.Failure("Invalid arguments for :setusetls. Expected: :setusetls <true|false>");
 
+            case "setproxy":
+                if (arguments.Count == 0)
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetWebSocketProxy, arguments));
+                }
+
+                if (arguments.Count <= 3
+                    && Uri.TryCreate(arguments[0], UriKind.Absolute, out var proxyUri)
+                    && proxyUri is { Host.Length: > 0 }
+                    && proxyUri.Scheme is "http" or "https")
+                {
+                    return CommandResult.SuccessCommand(new ParsedCommand(CommandType.SetWebSocketProxy, arguments));
+                }
+
+                return CommandResult.Failure(
+                    "Invalid arguments for :setproxy. Expected: :setproxy [<http[s]://host:port> [<username> [<password>]]]. Omit arguments to clear.");
+
             case "settings":
                 if (arguments.Count == 0)
                 {

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -1094,7 +1094,10 @@ public class MainViewModel : ReactiveObject, IDisposable, IStatusBarService // I
             SubscriptionQoS = Settings.SubscriptionQoS,
             SubscriptionTopic = Settings.SubscriptionTopic,
             Transport = Settings.SelectedTransport,
-            WebSocketPath = Settings.WebSocketPath
+            WebSocketPath = Settings.WebSocketPath,
+            WebSocketProxyAddress = Settings.WebSocketProxyAddress,
+            WebSocketProxyUsername = Settings.WebSocketProxyUsername,
+            WebSocketProxyPassword = Settings.WebSocketProxyPassword
         });
 
         _mqttService.ConnectionStateChanged += OnConnectionStateChanged;
@@ -2601,7 +2604,10 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
             SubscriptionQoS = Settings.SubscriptionQoS,
             SubscriptionTopic = Settings.SubscriptionTopic,
             Transport = Settings.SelectedTransport,
-            WebSocketPath = Settings.WebSocketPath
+            WebSocketPath = Settings.WebSocketPath,
+            WebSocketProxyAddress = Settings.WebSocketProxyAddress,
+            WebSocketProxyUsername = Settings.WebSocketProxyUsername,
+            WebSocketProxyPassword = Settings.WebSocketProxyPassword
         };
         
         _mqttService.UpdateSettings(connectionSettings);
@@ -3475,6 +3481,29 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
                         Log.Warning("Invalid arguments for SetUseTls command.");
                     }
                     break;
+                case CommandType.SetWebSocketProxy:
+                    if (command.Arguments.Count == 0)
+                    {
+                        this.Settings.WebSocketProxyAddress = null;
+                        this.Settings.WebSocketProxyUsername = null;
+                        this.Settings.WebSocketProxyPassword = null;
+                        StatusBarText = "WebSocket proxy cleared. Reconnect for the change to take effect.";
+                        Log.Information("WebSocket proxy cleared via command.");
+                    }
+                    else
+                    {
+                        this.Settings.WebSocketProxyAddress = command.Arguments[0];
+                        this.Settings.WebSocketProxyUsername = command.Arguments.Count >= 2
+                            ? command.Arguments[1]
+                            : null;
+                        this.Settings.WebSocketProxyPassword = command.Arguments.Count >= 3
+                            ? command.Arguments[2]
+                            : null;
+                        StatusBarText =
+                            $"WebSocket proxy set to '{command.Arguments[0]}'. Reconnect for the change to take effect.";
+                        Log.Information("WebSocket proxy configured via command: {Address}", command.Arguments[0]);
+                    }
+                    break;
                 case CommandType.Publish:
                     HandlePublishCommand(command);
                     break;
@@ -3520,6 +3549,7 @@ private void ProcessMessageBatchOnUIThread(List<IdentifiedMqttApplicationMessage
         { "setsubscription", (":setsubscription [<topic-filter>]", "Sets the MQTT topic filter used for the initial subscription. Defaults to '#' (all topics); Azure Event Grid requires a filter matching your Topic Space template (e.g. 'sensors/#'). Reconnect after changing.") },
         { "azurewhoami", (":azurewhoami", "Prints the identity (upn, oid, name, appid) that DefaultAzureCredential would use for Azure Event Grid token acquisition. Useful for choosing the correct Event Grid Client authenticationName.") },
         { "setusetls", (":setusetls <true|false>", "Sets whether to use TLS for MQTT connections. true = enable TLS, false = disable TLS.") },
+        { "setproxy", (":setproxy [<http[s]://host:port> [<username> [<password>]]]", "Configures the forward proxy used only for WebSocket transport. Omit arguments to clear it; reconnect after changing.") },
         { "deletetopic", (":deletetopic [topic-pattern] [--confirm]", "Deletes retained messages from a topic and its subtopics by publishing empty retained messages. Uses selected topic if no pattern specified.") },
         { "gotoresponse", (":gotoresponse", "Navigates to the response message for the currently selected MQTT v5 request message.") },
         { "settings", (":settings", "Toggles the visibility of the settings pane.") },

--- a/src/UI/ViewModels/SettingsViewModel.cs
+++ b/src/UI/ViewModels/SettingsViewModel.cs
@@ -113,6 +113,27 @@ public class SettingsViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _webSocketPath, value);
     }
 
+    private string? _webSocketProxyAddress;
+    public string? WebSocketProxyAddress
+    {
+        get => _webSocketProxyAddress;
+        set => this.RaiseAndSetIfChanged(ref _webSocketProxyAddress, value);
+    }
+
+    private string? _webSocketProxyUsername;
+    public string? WebSocketProxyUsername
+    {
+        get => _webSocketProxyUsername;
+        set => this.RaiseAndSetIfChanged(ref _webSocketProxyUsername, value);
+    }
+
+    private string? _webSocketProxyPassword;
+    public string? WebSocketProxyPassword
+    {
+        get => _webSocketProxyPassword;
+        set => this.RaiseAndSetIfChanged(ref _webSocketProxyPassword, value);
+    }
+
     private int _subscriptionQoS = 1;
     /// <summary>
     /// QoS level for the wildcard subscription (0, 1, or 2). Default: 1 (AtLeastOnce).
@@ -192,9 +213,12 @@ public class SettingsViewModel : ReactiveObject
         var transportPropertiesChanged = Observable.CombineLatest(
             this.WhenAnyValue(x => x.SelectedTransport),
             this.WhenAnyValue(x => x.WebSocketPath),
+            this.WhenAnyValue(x => x.WebSocketProxyAddress),
+            this.WhenAnyValue(x => x.WebSocketProxyUsername),
+            this.WhenAnyValue(x => x.WebSocketProxyPassword),
             this.WhenAnyValue(x => x.AuthenticationScope),
             this.WhenAnyValue(x => x.SubscriptionTopic),
-            (_, _, _, _) => Unit.Default);
+            (_, _, _, _, _, _, _) => Unit.Default);
 
         // Observable for changes within the TopicSpecificLimits collection (add/remove)
         var collectionChanged = Observable.FromEventPattern<System.Collections.Specialized.NotifyCollectionChangedEventHandler, System.Collections.Specialized.NotifyCollectionChangedEventArgs>(
@@ -483,7 +507,10 @@ public class SettingsViewModel : ReactiveObject
             SubscriptionQoS: SubscriptionQoS,
             Transport: SelectedTransport,
             WebSocketPath: WebSocketPath,
-            SubscriptionTopic: SubscriptionTopic
+            SubscriptionTopic: SubscriptionTopic,
+            WebSocketProxyAddress: WebSocketProxyAddress,
+            WebSocketProxyUsername: WebSocketProxyUsername,
+            WebSocketProxyPassword: WebSocketProxyPassword
         )
         {
             TopicSpecificBufferLimits = topicLimits
@@ -513,6 +540,9 @@ public class SettingsViewModel : ReactiveObject
             SubscriptionTopic = settingsData.SubscriptionTopic;
             SelectedTransport = settingsData.Transport;
             WebSocketPath = settingsData.WebSocketPath;
+            WebSocketProxyAddress = settingsData.WebSocketProxyAddress;
+            WebSocketProxyUsername = settingsData.WebSocketProxyUsername;
+            WebSocketProxyPassword = settingsData.WebSocketProxyPassword;
             TopicSpecificLimits.Clear();
 
             // Ensure we always have the default '#' limit
@@ -606,6 +636,9 @@ public class SettingsViewModel : ReactiveObject
             if (overrides.ExportPath != null) ExportPath = overrides.ExportPath;
             if (overrides.Transport.HasValue) SelectedTransport = overrides.Transport.Value;
             if (overrides.WebSocketPath != null) WebSocketPath = overrides.WebSocketPath;
+            if (overrides.WebSocketProxyAddress != null) WebSocketProxyAddress = overrides.WebSocketProxyAddress;
+            if (overrides.WebSocketProxyUsername != null) WebSocketProxyUsername = overrides.WebSocketProxyUsername;
+            if (overrides.WebSocketProxyPassword != null) WebSocketProxyPassword = overrides.WebSocketProxyPassword;
 
             if (overrides.AuthMode != null)
             {

--- a/src/UI/Views/MainView.axaml
+++ b/src/UI/Views/MainView.axaml
@@ -451,7 +451,7 @@
           </Grid> <!-- End of Main Content Grid -->
 
           <Panel Grid.Row="0" Grid.Column="1" IsVisible="{Binding IsSettingsVisible}" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5"> <!-- 26 rows (0-25); row 23 added for Subscription Topic -->
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="5">
                 <Grid.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -501,58 +501,78 @@
                          PlaceholderText="/mqtt"
                          IsVisible="{Binding Settings.IsWebSocketSelected}"/>
 
+                <!-- WebSocket Proxy (Conditionally Visible) -->
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="WS Proxy:" IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+                <TextBox Grid.Row="6" Grid.Column="1"
+                         Text="{Binding Settings.WebSocketProxyAddress, Mode=TwoWay}"
+                         PlaceholderText="http://proxy:3128"
+                         IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+
+                <TextBlock Grid.Row="7" Grid.Column="0" Text="Proxy User:" IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+                <TextBox Grid.Row="7" Grid.Column="1"
+                         Text="{Binding Settings.WebSocketProxyUsername, Mode=TwoWay}"
+                         PlaceholderText="(optional)"
+                         IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+
+                <TextBlock Grid.Row="8" Grid.Column="0" Text="Proxy Password:" IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+                <TextBox Grid.Row="8" Grid.Column="1"
+                         Text="{Binding Settings.WebSocketProxyPassword, Mode=TwoWay}"
+                         PlaceholderText="(optional)"
+                         PasswordChar="*"
+                         IsVisible="{Binding Settings.IsWebSocketSelected}"/>
+
                 <!-- Client ID -->
-                <TextBlock Grid.Row="6" Grid.Column="0" Text="Client ID:"/>
-                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" PlaceholderText="(auto-generated)"/>
+                <TextBlock Grid.Row="9" Grid.Column="0" Text="Client ID:"/>
+                <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding Settings.ClientId, Mode=TwoWay}" PlaceholderText="(auto-generated)"/>
 
                 <!-- Keep Alive -->
-                <TextBlock Grid.Row="7" Grid.Column="0" Text="Keep Alive (s):"/>
-                <NumericUpDown Grid.Row="7" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
+                <TextBlock Grid.Row="10" Grid.Column="0" Text="Keep Alive (s):"/>
+                <NumericUpDown Grid.Row="10" Grid.Column="1" Value="{Binding Settings.KeepAliveIntervalSeconds, Mode=TwoWay, StringFormat=N0}"  ParsingNumberStyle="Integer" MinWidth="80" Minimum="0"/>
                 
                 <!-- Clean Session -->
-                <TextBlock Grid.Row="8" Grid.Column="0" Text="Clean Session:"/>
-                <CheckBox Grid.Row="8" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
+                <TextBlock Grid.Row="11" Grid.Column="0" Text="Clean Session:"/>
+                <CheckBox Grid.Row="11" Grid.Column="1" IsChecked="{Binding Settings.CleanSession, Mode=TwoWay}" Margin="10,0,0,0"/>
 
                 <!-- Session Expiry -->
-                <TextBlock Grid.Row="9" Grid.Column="0" Text="Session Expiry (s):"/>
-                <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Vertical" Spacing="5">
+                <TextBlock Grid.Row="12" Grid.Column="0" Text="Session Expiry (s):"/>
+                <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Vertical" Spacing="5">
                     <NumericUpDown Value="{Binding Settings.SessionExpiryIntervalSeconds, Mode=TwoWay}" MinWidth="120"  FormatString="N0" Minimum="0" PlaceholderText="(infinite)"/>
                     <TextBlock Text="(0 = expires immediately, empty = infinite)" FontSize="10"/>
                 </StackPanel>
 
                 <!-- Authentication Mode -->
-                <TextBlock Grid.Row="10" Grid.Column="0" Text="Auth Mode:"/>
-                <ComboBox Grid.Row="10" Grid.Column="1"
+                <TextBlock Grid.Row="13" Grid.Column="0" Text="Auth Mode:"/>
+                <ComboBox Grid.Row="13" Grid.Column="1"
                             ItemsSource="{Binding Settings.AvailableAuthenticationModes}"
                             SelectedItem="{Binding Settings.SelectedAuthMode, Mode=TwoWay}"
                             MinWidth="220"/>
 
                 <!-- Auth Username (Conditionally Visible) -->
-                <TextBlock Grid.Row="11" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox Grid.Row="11" Grid.Column="1"
+                <TextBlock Grid.Row="14" Grid.Column="0" Text="Username:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox Grid.Row="14" Grid.Column="1"
                          Text="{Binding Settings.AuthUsername, Mode=TwoWay}"
                          PlaceholderText="Enter username"
                          IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
 
                 <!-- Auth Password (Conditionally Visible) -->
-                <TextBlock Grid.Row="12" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
-                <TextBox  Grid.Row="12" Grid.Column="1"
+                <TextBlock Grid.Row="15" Grid.Column="0" Text="Password:" IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
+                <TextBox  Grid.Row="15" Grid.Column="1"
                              Text="{Binding Settings.AuthPassword, Mode=TwoWay}"
                              PlaceholderText="Enter password" PasswordChar="*"
                              IsVisible="{Binding Settings.IsUsernamePasswordSelected}"/>
                 
                 <!-- Enhanced Authentication Header -->
-                <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="Enhanced Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Method -->
-                <TextBlock Grid.Row="14" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
-                <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" PlaceholderText="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="17" Grid.Column="0" Text="Auth Method:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBox Grid.Row="17" Grid.Column="1" Text="{Binding Settings.AuthenticationMethod, Mode=TwoWay}" PlaceholderText="e.g., 'K8S-SAT'" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
 
                 <!-- Authentication Data -->
-                <TextBlock Grid.Row="15" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
+                <TextBlock Grid.Row="18" Grid.Column="0" Text="Auth Data:" IsVisible="{Binding Settings.IsEnhancedAuthSelected}"/>
                 
                 <ScrollViewer                            
-                            Grid.Row="15"
+                            Grid.Row="18"
                             Grid.Column="1"
                             IsVisible="{Binding Settings.IsEnhancedAuthSelected}"
                             HorizontalScrollBarVisibility="Visible"
@@ -570,32 +590,32 @@
                 </ScrollViewer>
 
                 <!-- Azure Authentication Header -->
-                <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Text="Azure Event Grid Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
+                <TextBlock Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Text="Azure Event Grid Authentication" FontWeight="Bold" FontSize="14" Margin="0,15,0,10" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
 
                 <!-- Azure OAuth Scope -->
-                <TextBlock Grid.Row="17" Grid.Column="0" Text="OAuth Scope:" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
-                <StackPanel Grid.Row="17" Grid.Column="1" Orientation="Vertical" Spacing="2" IsVisible="{Binding Settings.IsAzureAuthSelected}">
+                <TextBlock Grid.Row="20" Grid.Column="0" Text="OAuth Scope:" IsVisible="{Binding Settings.IsAzureAuthSelected}"/>
+                <StackPanel Grid.Row="20" Grid.Column="1" Orientation="Vertical" Spacing="2" IsVisible="{Binding Settings.IsAzureAuthSelected}">
                     <TextBox Text="{Binding Settings.AuthenticationScope, Mode=TwoWay}" PlaceholderText="https://eventgrid.azure.net/.default"/>
                     <TextBlock Text="Uses DefaultAzureCredential (env vars → managed identity → VS → az CLI → interactive). Token is refreshed automatically before expiry." FontSize="10" TextWrapping="Wrap"/>
                 </StackPanel>
 
                 <!-- General Settings Header -->
-                <TextBlock Grid.Row="18" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" Text="General Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Export Format -->
-                <TextBlock Grid.Row="19" Grid.Column="0" Text="Export Format:"/>
-                <ComboBox Grid.Row="19" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
+                <TextBlock Grid.Row="22" Grid.Column="0" Text="Export Format:"/>
+                <ComboBox Grid.Row="22" Grid.Column="1" ItemsSource="{Binding Settings.AvailableExportTypes}" SelectedItem="{Binding Settings.ExportFormat, Mode=TwoWay}" MinWidth="220" />
 
                 <!-- Export Path -->
-                <TextBlock Grid.Row="20" Grid.Column="0" Text="Export Path:"/>
-                <TextBox Grid.Row="20" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
+                <TextBlock Grid.Row="23" Grid.Column="0" Text="Export Path:"/>
+                <TextBox Grid.Row="23" Grid.Column="1" Text="{Binding Settings.ExportPath, Mode=TwoWay}" />
 
                 <!-- Application Settings Header -->
-                <TextBlock Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
+                <TextBlock Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" Text="Application Settings" FontWeight="Bold" FontSize="14" Margin="0,15,0,10"/>
 
                 <!-- Subscription QoS -->
-                <TextBlock Grid.Row="22" Grid.Column="0" Text="Subscription QoS:"/>
-                <Grid Grid.Row="22" Grid.Column="1" RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="25" Grid.Column="0" Text="Subscription QoS:"/>
+                <Grid Grid.Row="25" Grid.Column="1" RowDefinitions="Auto,Auto">
                     <ComboBox Grid.Row="0" SelectedIndex="{Binding Settings.SubscriptionQoS, Mode=TwoWay}" MinWidth="120">
                         <ComboBoxItem Content="0 - At Most Once"/>
                         <ComboBoxItem Content="1 - At Least Once (Default)"/>
@@ -605,14 +625,14 @@
                 </Grid>
 
                 <!-- Subscription Topic -->
-                <TextBlock Grid.Row="23" Grid.Column="0" Text="Subscription Topic:"/>
-                <StackPanel Grid.Row="23" Grid.Column="1" Orientation="Vertical" Spacing="2">
+                <TextBlock Grid.Row="26" Grid.Column="0" Text="Subscription Topic:"/>
+                <StackPanel Grid.Row="26" Grid.Column="1" Orientation="Vertical" Spacing="2">
                     <TextBox Text="{Binding Settings.SubscriptionTopic, Mode=TwoWay}" PlaceholderText="#"/>
                     <TextBlock Text="Wildcard '#' works for open brokers (EMQX/Mosquitto). Azure Event Grid requires a filter that matches your Topic Space template (e.g. 'sensors/#' or 'devices/+/telemetry')." FontSize="10" TextWrapping="Wrap"/>
                 </StackPanel>
 
                 <!-- Topic Buffer Limits List -->
-                <ItemsControl Grid.Row="24" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
+                <ItemsControl Grid.Row="27" Grid.Column="0" Grid.ColumnSpan="2" ItemsSource="{Binding Settings.TopicSpecificLimits}" Margin="0,0,0,5">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:TopicBufferLimitViewModel}">
                             <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto" Margin="0,2">
@@ -625,7 +645,7 @@
                 </ItemsControl>
 
                 <!-- Add New Limit Button -->
-                <Button Grid.Row="25" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                <Button Grid.Row="28" Grid.Column="0" Grid.ColumnSpan="2" Content="Add New Limit" Command="{Binding Settings.AddTopicLimitCommand}" HorizontalAlignment="Left" Margin="0,5,0,0"/>
 
             </Grid>
         </Panel>

--- a/tests/AppHost.Tests/SquidProxyConfigurationTests.cs
+++ b/tests/AppHost.Tests/SquidProxyConfigurationTests.cs
@@ -1,0 +1,48 @@
+namespace CrowsNestMqtt.AppHostTests;
+
+using Xunit;
+
+public sealed class SquidProxyConfigurationTests
+{
+    [Fact]
+    public void AppHost_MountsSquidPolicyThatAllowsEmqxWebSocketConnect()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var squidConfigPath = Path.Combine(
+            repositoryRoot,
+            "src",
+            "AppHost",
+            "squid",
+            "crowsnest.conf");
+        var appHostProgramPath = Path.Combine(
+            repositoryRoot,
+            "src",
+            "AppHost",
+            "Program.cs");
+
+        Assert.True(File.Exists(squidConfigPath), $"Missing Squid configuration: {squidConfigPath}");
+
+        var squidConfig = File.ReadAllText(squidConfigPath);
+        Assert.Contains("acl SSL_ports port 8083", squidConfig, StringComparison.Ordinal);
+        Assert.Contains("http_access allow localnet CONNECT", squidConfig, StringComparison.Ordinal);
+
+        var appHostProgram = File.ReadAllText(appHostProgramPath);
+        Assert.Contains(
+            ".WithBindMount(\"./squid/crowsnest.conf\", \"/etc/squid/conf.d/crowsnest.conf\", isReadOnly: true)",
+            appHostProgram,
+            StringComparison.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "CrowsNestMQTT.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException(
+                $"Could not locate repository root from {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/UnitTests/CommandParserServiceTests.cs
+++ b/tests/UnitTests/CommandParserServiceTests.cs
@@ -422,4 +422,41 @@ public class CommandParserServiceTests
         Assert.False(result.IsSuccess);
         Assert.Contains(":setsubscription", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Theory]
+    [InlineData(":setproxy http://proxy.local:3128", new[] { "http://proxy.local:3128" })]
+    [InlineData(":setproxy http://proxy.local:3128 proxy-user", new[] { "http://proxy.local:3128", "proxy-user" })]
+    [InlineData(":setproxy http://proxy.local:3128 proxy-user proxy-pass", new[] { "http://proxy.local:3128", "proxy-user", "proxy-pass" })]
+    public void ParseCommand_SetProxy_WithValidArguments_Succeeds(string input, string[] expectedArguments)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetWebSocketProxy, result.ParsedCommand.Type);
+        Assert.Equal(expectedArguments, result.ParsedCommand.Arguments);
+    }
+
+    [Fact]
+    public void ParseCommand_SetProxy_NoArguments_ClearsProxy()
+    {
+        var result = CommandParserService.ParseCommand(":setproxy", _settings);
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.NotNull(result.ParsedCommand);
+        Assert.Equal(CommandType.SetWebSocketProxy, result.ParsedCommand.Type);
+        Assert.Empty(result.ParsedCommand.Arguments);
+    }
+
+    [Theory]
+    [InlineData(":setproxy proxy.local:3128")]
+    [InlineData(":setproxy ftp://proxy.local:21")]
+    [InlineData(":setproxy http://proxy.local:3128 user pass extra")]
+    public void ParseCommand_SetProxy_WithInvalidArguments_Fails(string input)
+    {
+        var result = CommandParserService.ParseCommand(input, _settings);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(":setproxy", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/UnitTests/MqttEngineTests.cs
+++ b/tests/UnitTests/MqttEngineTests.cs
@@ -390,6 +390,51 @@ public class MqttEngineTests
     }
 
     [Fact]
+    public void BuildMqttOptions_WithWebSocketProxy_ShouldConfigureProxyAddressAndCredentials()
+    {
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "broker.example.com",
+            Port = 8083,
+            Transport = TransportProtocol.WebSocket,
+            WebSocketPath = "/mqtt",
+            WebSocketProxyAddress = "http://proxy.example.com:3128",
+            WebSocketProxyUsername = "proxy-user",
+            WebSocketProxyPassword = "proxy-pass"
+        };
+        using var engine = new MqttEngine(settings);
+
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        Assert.NotNull(options);
+        var wsOptions = Assert.IsType<MqttClientWebSocketOptions>(options.ChannelOptions);
+        Assert.NotNull(wsOptions.ProxyOptions);
+        Assert.Equal("http://proxy.example.com:3128", wsOptions.ProxyOptions.Address);
+        Assert.Equal("proxy-user", wsOptions.ProxyOptions.Username);
+        Assert.Equal("proxy-pass", wsOptions.ProxyOptions.Password);
+    }
+
+    [Fact]
+    public void BuildMqttOptions_WithTcpTransport_ShouldIgnoreWebSocketProxy()
+    {
+        var settings = new MqttConnectionSettings
+        {
+            Hostname = "broker.local",
+            Port = 1883,
+            Transport = TransportProtocol.Tcp,
+            WebSocketProxyAddress = "http://proxy.example.com:3128"
+        };
+        using var engine = new MqttEngine(settings);
+
+        var methodInfo = typeof(MqttEngine).GetMethod("BuildMqttOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var options = methodInfo?.Invoke(engine, null) as MqttClientOptions;
+
+        Assert.NotNull(options);
+        Assert.IsType<MqttClientTcpOptions>(options.ChannelOptions);
+    }
+
+    [Fact]
     public void BuildMqttOptions_WithTcpTransport_ShouldUseTcpChannel()
     {
         // Arrange

--- a/tests/UnitTests/ProgramTests.cs
+++ b/tests/UnitTests/ProgramTests.cs
@@ -370,6 +370,30 @@ namespace CrowsNestMqtt.UnitTests
         }
 
         [Fact]
+        public void EnvironmentSettingsOverrides_ParsesWebSocketProxySettings()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_ADDRESS", "http://proxy.local:3128");
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_USERNAME", "proxy-user");
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_PASSWORD", "proxy-pass");
+
+                var result = EnvironmentSettingsOverrides.Load();
+
+                Assert.True(result.HasOverrides);
+                Assert.Equal("http://proxy.local:3128", result.WebSocketProxyAddress);
+                Assert.Equal("proxy-user", result.WebSocketProxyUsername);
+                Assert.Equal("proxy-pass", result.WebSocketProxyPassword);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_ADDRESS", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_USERNAME", null);
+                Environment.SetEnvironmentVariable("CROWSNEST__WEBSOCKET_PROXY_PASSWORD", null);
+            }
+        }
+
+        [Fact]
         public void EnvironmentSettingsOverrides_DetectsWsEndpointName()
         {
             // Aspire sets services__mqtt__ws__0 when referencing a "ws" named endpoint

--- a/tests/UnitTests/ViewModels/DispatchCommandTests.cs
+++ b/tests/UnitTests/ViewModels/DispatchCommandTests.cs
@@ -363,6 +363,36 @@ public class DispatchCommandTests : IDisposable
     }
 
     [Fact]
+    public void DispatchCommand_SetWebSocketProxy_WithCredentials_ShouldSetProxy()
+    {
+        Dispatch(
+            CommandType.SetWebSocketProxy,
+            "http://proxy.local:3128",
+            "proxy-user",
+            "proxy-pass");
+
+        Assert.Equal("http://proxy.local:3128", _viewModel.Settings.WebSocketProxyAddress);
+        Assert.Equal("proxy-user", _viewModel.Settings.WebSocketProxyUsername);
+        Assert.Equal("proxy-pass", _viewModel.Settings.WebSocketProxyPassword);
+        Assert.Contains("proxy.local:3128", _viewModel.StatusBarText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DispatchCommand_SetWebSocketProxy_NoArgs_ShouldClearProxy()
+    {
+        _viewModel.Settings.WebSocketProxyAddress = "http://proxy.local:3128";
+        _viewModel.Settings.WebSocketProxyUsername = "proxy-user";
+        _viewModel.Settings.WebSocketProxyPassword = "proxy-pass";
+
+        Dispatch(CommandType.SetWebSocketProxy);
+
+        Assert.Null(_viewModel.Settings.WebSocketProxyAddress);
+        Assert.Null(_viewModel.Settings.WebSocketProxyUsername);
+        Assert.Null(_viewModel.Settings.WebSocketProxyPassword);
+        Assert.Contains("cleared", _viewModel.StatusBarText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void DispatchCommand_Settings_ShouldToggleSettings()
     {
         bool initial = _viewModel.IsSettingsVisible;

--- a/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -192,6 +192,61 @@ public class SettingsViewModelTests
         Assert.True(vm.IsWebSocketSelected);
     }
 
+    [Fact]
+    public void Into_SettingsData_HasWebSocketProxyConfiguration()
+    {
+        var vm = new SettingsViewModel
+        {
+            WebSocketProxyAddress = "http://proxy.local:3128",
+            WebSocketProxyUsername = "proxy-user",
+            WebSocketProxyPassword = "proxy-pass"
+        };
+
+        var settingsData = vm.Into();
+
+        Assert.Equal("http://proxy.local:3128", settingsData.WebSocketProxyAddress);
+        Assert.Equal("proxy-user", settingsData.WebSocketProxyUsername);
+        Assert.Equal("proxy-pass", settingsData.WebSocketProxyPassword);
+    }
+
+    [Fact]
+    public void From_SettingsData_SetsWebSocketProxyConfiguration()
+    {
+        var settingsData = new SettingsData(
+            "host",
+            8083,
+            Transport: TransportProtocol.WebSocket,
+            WebSocketProxyAddress: "http://proxy.local:3128",
+            WebSocketProxyUsername: "proxy-user",
+            WebSocketProxyPassword: "proxy-pass");
+        var vm = new SettingsViewModel();
+
+        vm.From(settingsData);
+
+        Assert.Equal("http://proxy.local:3128", vm.WebSocketProxyAddress);
+        Assert.Equal("proxy-user", vm.WebSocketProxyUsername);
+        Assert.Equal("proxy-pass", vm.WebSocketProxyPassword);
+    }
+
+    [Fact]
+    public void ApplyEnvironmentOverrides_SetsWebSocketProxyConfiguration()
+    {
+        var vm = new SettingsViewModel();
+        var overrides = new EnvironmentSettingsOverrides
+        {
+            WebSocketProxyAddress = "http://proxy.local:3128",
+            WebSocketProxyUsername = "proxy-user",
+            WebSocketProxyPassword = "proxy-pass",
+            HasOverrides = true
+        };
+
+        vm.ApplyEnvironmentOverrides(overrides);
+
+        Assert.Equal("http://proxy.local:3128", vm.WebSocketProxyAddress);
+        Assert.Equal("proxy-user", vm.WebSocketProxyUsername);
+        Assert.Equal("proxy-pass", vm.WebSocketProxyPassword);
+    }
+
     // --- Azure (Event Grid OAUTH2-JWT) tests ---
 
     [Fact]

--- a/tests/integration/Integration.Tests.csproj
+++ b/tests/integration/Integration.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MQTTnet.Server" />
+    <PackageReference Include="MQTTnet.AspNetCore" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/integration/MqttWebSocketProxyIntegrationTests.cs
+++ b/tests/integration/MqttWebSocketProxyIntegrationTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using CrowsNestMqtt.BusinessLogic;
+using CrowsNestMqtt.BusinessLogic.Configuration;
+using MQTTnet.Protocol;
+using Xunit;
+
+namespace CrowsNestMqtt.Integration.Tests;
+
+public sealed class MqttWebSocketProxyIntegrationTests
+    : IClassFixture<WebSocketProxyBrokerFixture>
+{
+    private readonly WebSocketProxyBrokerFixture _fixture;
+
+    public MqttWebSocketProxyIntegrationTests(WebSocketProxyBrokerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task MqttEngine_ShouldPublishAndReceiveThroughConfiguredWebSocketProxy()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var topic = $"proxy/integration/{Guid.NewGuid():N}";
+        const string payload = "through-the-proxy";
+        var connected = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var received = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var engine = new MqttEngine(new MqttConnectionSettings
+        {
+            Hostname = _fixture.Hostname,
+            Port = _fixture.WebSocketPort,
+            ClientId = $"proxy-test-{Guid.NewGuid():N}",
+            Transport = TransportProtocol.WebSocket,
+            WebSocketPath = "/mqtt",
+            WebSocketProxyAddress = $"http://{_fixture.Hostname}:{_fixture.ProxyPort}",
+            SubscriptionTopic = topic
+        });
+
+        engine.ConnectionStateChanged += (_, args) =>
+        {
+            if (args.IsConnected)
+            {
+                connected.TrySetResult();
+            }
+        };
+        engine.MessagesBatchReceived += (_, batch) =>
+        {
+            var message = batch.FirstOrDefault(item => item.Topic == topic);
+            if (message != null)
+            {
+                received.TrySetResult(Encoding.UTF8.GetString(message.ApplicationMessage.Payload));
+            }
+        };
+
+        await engine.ConnectAsync(cts.Token);
+        await connected.Task.WaitAsync(cts.Token);
+        await Task.Delay(500, cts.Token);
+
+        await engine.PublishAsync(
+            topic,
+            payload,
+            qos: MqttQualityOfServiceLevel.AtLeastOnce,
+            cancellationToken: cts.Token);
+
+        Assert.Equal(payload, await received.Task.WaitAsync(cts.Token));
+        Assert.True(_fixture.ProxyConnectionCount > 0);
+        Assert.Contains(
+            _fixture.WebSocketPort.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            _fixture.LastProxyRequestLine,
+            StringComparison.Ordinal);
+
+        await engine.DisconnectAsync(CancellationToken.None);
+    }
+}

--- a/tests/integration/WebSocketProxyBrokerFixture.cs
+++ b/tests/integration/WebSocketProxyBrokerFixture.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using MQTTnet.AspNetCore;
+using MQTTnet.Server;
+using Xunit;
+
+namespace CrowsNestMqtt.Integration.Tests;
+
+public sealed class WebSocketProxyBrokerFixture : IAsyncLifetime
+{
+    private readonly CancellationTokenSource _proxyCancellation = new();
+    private WebApplication? _brokerApplication;
+    private TcpListener? _proxyListener;
+    private Task? _proxyAcceptLoop;
+    private int _proxyConnectionCount;
+
+    public string Hostname => IPAddress.Loopback.ToString();
+    public int WebSocketPort { get; private set; }
+    public int ProxyPort { get; private set; }
+    public int ProxyConnectionCount => Volatile.Read(ref _proxyConnectionCount);
+    public string? LastProxyRequestLine { get; private set; }
+
+    public async ValueTask InitializeAsync()
+    {
+        WebSocketPort = GetRandomPort();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseKestrel(options => options.Listen(IPAddress.Loopback, WebSocketPort));
+        builder.Services
+            .AddHostedMqttServer(options => options.WithoutDefaultEndpoint())
+            .AddMqttConnectionHandler()
+            .AddConnections();
+
+        _brokerApplication = builder.Build();
+        _brokerApplication.MapConnectionHandler<MqttConnectionHandler>(
+            "/mqtt",
+            options => options.WebSockets.SubProtocolSelector =
+                protocols => protocols.FirstOrDefault() ?? string.Empty);
+        _brokerApplication.UseMqttServer(_ => { });
+        await _brokerApplication.StartAsync().ConfigureAwait(false);
+
+        _proxyListener = new TcpListener(IPAddress.Loopback, 0);
+        _proxyListener.Start();
+        ProxyPort = ((IPEndPoint)_proxyListener.LocalEndpoint).Port;
+        _proxyAcceptLoop = AcceptProxyConnectionsAsync(_proxyCancellation.Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _proxyCancellation.CancelAsync().ConfigureAwait(false);
+        _proxyListener?.Stop();
+        _proxyListener?.Dispose();
+
+        if (_proxyAcceptLoop != null)
+        {
+            try
+            {
+                await _proxyAcceptLoop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        if (_brokerApplication != null)
+        {
+            await _brokerApplication.StopAsync().ConfigureAwait(false);
+            await _brokerApplication.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _proxyCancellation.Dispose();
+    }
+
+    private async Task AcceptProxyConnectionsAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await _proxyListener!.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (SocketException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _ = Task.Run(() => HandleProxyConnectionAsync(client, cancellationToken), CancellationToken.None);
+        }
+    }
+
+    private async Task HandleProxyConnectionAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            var clientStream = client.GetStream();
+            var requestBytes = await ReadHttpHeadersAsync(clientStream, cancellationToken).ConfigureAwait(false);
+            var requestText = Encoding.ASCII.GetString(requestBytes);
+            var firstLineEnd = requestText.IndexOf("\r\n", StringComparison.Ordinal);
+            if (firstLineEnd < 0)
+            {
+                return;
+            }
+
+            var firstLine = requestText[..firstLineEnd];
+            LastProxyRequestLine = firstLine;
+            Interlocked.Increment(ref _proxyConnectionCount);
+
+            var parts = firstLine.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 3)
+            {
+                return;
+            }
+
+            using var upstream = new TcpClient();
+            if (parts[0].Equals("CONNECT", StringComparison.OrdinalIgnoreCase))
+            {
+                var destination = parts[1].Split(':', 2);
+                if (destination.Length != 2 || !int.TryParse(destination[1], out var port))
+                {
+                    return;
+                }
+
+                await upstream.ConnectAsync(destination[0], port, cancellationToken).ConfigureAwait(false);
+                await clientStream.WriteAsync(
+                    Encoding.ASCII.GetBytes("HTTP/1.1 200 Connection Established\r\n\r\n"),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (!Uri.TryCreate(parts[1], UriKind.Absolute, out var destination))
+                {
+                    return;
+                }
+
+                var port = destination.IsDefaultPort
+                    ? destination.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? 443 : 80
+                    : destination.Port;
+                await upstream.ConnectAsync(destination.Host, port, cancellationToken).ConfigureAwait(false);
+
+                var rewrittenRequest = Encoding.ASCII.GetBytes(
+                    $"{parts[0]} {destination.PathAndQuery} {parts[2]}{requestText[firstLineEnd..]}");
+                await upstream.GetStream().WriteAsync(rewrittenRequest, cancellationToken).ConfigureAwait(false);
+            }
+
+            var upstreamStream = upstream.GetStream();
+            await Task.WhenAll(
+                clientStream.CopyToAsync(upstreamStream, cancellationToken),
+                upstreamStream.CopyToAsync(clientStream, cancellationToken)).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<byte[]> ReadHttpHeadersAsync(
+        NetworkStream stream,
+        CancellationToken cancellationToken)
+    {
+        using var buffer = new MemoryStream();
+        var chunk = new byte[1024];
+
+        while (buffer.Length < 64 * 1024)
+        {
+            var read = await stream.ReadAsync(chunk, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            await buffer.WriteAsync(chunk.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            if (buffer.Length >= 4)
+            {
+                var bytes = buffer.GetBuffer();
+                var length = (int)buffer.Length;
+                if (bytes[length - 4] == '\r'
+                    && bytes[length - 3] == '\n'
+                    && bytes[length - 2] == '\r'
+                    && bytes[length - 1] == '\n')
+                {
+                    return buffer.ToArray();
+                }
+            }
+        }
+
+        throw new InvalidDataException("Proxy request did not contain a complete HTTP header block.");
+    }
+
+    private static int GetRandomPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tools/SendTestData.ps1
+++ b/tools/SendTestData.ps1
@@ -67,6 +67,8 @@ if ($null -ne $UseTls) {
 
 $clientId = "pwsh-mqtt-$(Get-Random)"
 $publishTimeout = [TimeSpan]::FromSeconds(30)
+$connectRetryCount = 12
+$connectRetryDelay = [TimeSpan]::FromSeconds(5)
 
 # Build MQTT client options (MQTTnet 5.x API)
 $optionsBuilder = [MQTTnet.MqttClientOptionsBuilder]::new()
@@ -80,10 +82,27 @@ $client = $factory.CreateMqttClient()
 
 $failedPublishes = [System.Collections.Generic.List[string]]::new()
 
+function Connect-MqttClientWithRetry {
+    for ($attempt = 1; $attempt -le $connectRetryCount; $attempt++) {
+        try {
+            $null = $client.ConnectAsync($options).WaitAsync($publishTimeout).GetAwaiter().GetResult()
+            return
+        } catch {
+            $message = $_.Exception.InnerException.Message ?? $_.Exception.Message
+            if ($attempt -eq $connectRetryCount) {
+                throw "Unable to connect to $mqttHost`:$port after $connectRetryCount attempts. Last error: $message"
+            }
+
+            Write-Warning "MQTT connection attempt $attempt/$connectRetryCount failed: $message. Retrying in $($connectRetryDelay.TotalSeconds) seconds..."
+            Start-Sleep -Seconds $connectRetryDelay.TotalSeconds
+        }
+    }
+}
+
 function Ensure-MqttConnected {
     if (-not $client.IsConnected) {
         Write-Host "Reconnecting to $mqttHost : $port ..."
-        $null = $client.ConnectAsync($options).WaitAsync($publishTimeout).GetAwaiter().GetResult()
+        Connect-MqttClientWithRetry
     }
 }
 
@@ -106,7 +125,7 @@ function Send-MqttMessage {
 
 # Connect
 Write-Host "Connecting to $mqttHost : $port with client id $clientId (TLS: $useTls)"
-$null = $client.ConnectAsync($options).WaitAsync($publishTimeout).GetAwaiter().GetResult()
+Connect-MqttClientWithRetry
 
 # Read image as bytes
 $imageBytes = [System.IO.File]::ReadAllBytes($ImagePath)


### PR DESCRIPTION
- Implemented the :setproxy command in CommandParserService to configure WebSocket proxy settings.
- Updated MainViewModel and SettingsViewModel to include properties for WebSocket proxy address, username, and password.
- Enhanced UI in MainView.axaml to allow users to input WebSocket proxy settings.
- Added integration tests for WebSocket proxy functionality in MqttWebSocketProxyIntegrationTests.
- Created WebSocketProxyBrokerFixture to facilitate testing of the WebSocket proxy.
- Updated various unit tests to validate the new proxy settings functionality.
- Enhanced SendTestData.ps1 script to include retry logic for MQTT client connections.