### PR TITLE
support windows mica/mac os and linux by setting transparency in code-behind dependent on the OS

### DIFF
--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Media;
 
 using FluentAvalonia.UI.Windowing;
 
@@ -22,5 +23,14 @@ public partial class MainWindow : FAAppWindow
         TitleBar.ExtendsContentIntoTitleBar = true;
 
         InitializeComponent();
+        ConfigurePlatformBackground(OperatingSystem.IsLinux());
+    }
+
+    internal void ConfigurePlatformBackground(bool isLinux)
+    {
+        if (!isLinux)
+        {
+            Background = Brushes.Transparent;
+        }
     }
 }

--- a/tests/UnitTests/UI/MainWindowTests.cs
+++ b/tests/UnitTests/UI/MainWindowTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls;
+using Avalonia.Media;
 using CrowsNestMqtt.UI.Views;
 using CrowsNestMqtt.UI.ViewModels;
 
@@ -94,6 +95,37 @@ namespace CrowsNestMqtt.UnitTests.UI
             // Assert
             // The title should be set in XAML, so let's verify it's not null or empty
             Assert.False(string.IsNullOrEmpty(mainWindow.Title));
+        }
+
+        [AvaloniaFact]
+        public void ConfigurePlatformBackground_OnLinux_PreservesOpaqueBackground()
+        {
+            // Arrange
+            var mainWindow = new MainWindow();
+            var opaqueBackground = new SolidColorBrush(Colors.Black);
+            mainWindow.Background = opaqueBackground;
+
+            // Act
+            mainWindow.ConfigurePlatformBackground(isLinux: true);
+
+            // Assert
+            Assert.Same(opaqueBackground, mainWindow.Background);
+        }
+
+        [AvaloniaFact]
+        public void ConfigurePlatformBackground_OnNonLinux_UsesTransparentBackground()
+        {
+            // Arrange
+            var mainWindow = new MainWindow
+            {
+                Background = new SolidColorBrush(Colors.Black)
+            };
+
+            // Act
+            mainWindow.ConfigurePlatformBackground(isLinux: false);
+
+            // Assert
+            Assert.Same(Brushes.Transparent, mainWindow.Background);
         }
 
         [AvaloniaFact]


### PR DESCRIPTION
This pull request updates the `MainWindow` background handling to improve cross-platform appearance and adds corresponding unit tests to ensure correct behavior on Linux and non-Linux systems.

Platform-specific background handling:

* Added a new `ConfigurePlatformBackground` method to `MainWindow` that sets the window background to transparent on non-Linux platforms, preserving the existing background on Linux. (`src/UI/Views/MainWindow.axaml.cs`)
* Updated the constructor of `MainWindow` to call `ConfigurePlatformBackground` with the current platform check. (`src/UI/Views/MainWindow.axaml.cs`)

Testing:

* Added unit tests to verify that `ConfigurePlatformBackground` preserves the background on Linux and sets it to transparent on non-Linux platforms. (`tests/UnitTests/UI/MainWindowTests.cs`)

Dependency updates:

* Added `Avalonia.Media` using directives to both the main window and test files to support brush operations. (`src/UI/Views/MainWindow.axaml.cs`, `tests/UnitTests/UI/MainWindowTests.cs`) [[1]](diffhunk://#diff-9a0f16fb78a8250ddf832ec49613aac25d01ec2ab37b7ec533d21e4afc443fccR2) [[2]](diffhunk://#diff-d487876b5ab79bf44f2c527b1dbe506ff9ff34e56ba345f9dd0c96e8ad5f93caR4)