### PR TITLE
Serialize test projects during coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,6 +69,7 @@ jobs:
           --output ./TestResults/coverage.cobertura.xml `
           --output-format cobertura `
           -- dotnet test --no-build --configuration Release `
+               --maxcpucount:1 `
                --filter "Category!=LocalOnly&Category!=RequiresMqttBroker" `
                --blame-hang --blame-hang-timeout 120s `
                --results-directory ./TestResults `

--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -23,14 +23,9 @@ public partial class MainWindow : FAAppWindow
         TitleBar.ExtendsContentIntoTitleBar = true;
 
         InitializeComponent();
-        ConfigurePlatformBackground(OperatingSystem.IsLinux());
+        Background = SelectPlatformBackground(OperatingSystem.IsLinux(), Background);
     }
 
-    internal void ConfigurePlatformBackground(bool isLinux)
-    {
-        if (!isLinux)
-        {
-            Background = Brushes.Transparent;
-        }
-    }
+    internal static IBrush? SelectPlatformBackground(bool isLinux, IBrush? currentBackground) =>
+        isLinux ? currentBackground : Brushes.Transparent;
 }

--- a/src/UI/Views/MainWindow.axaml.cs
+++ b/src/UI/Views/MainWindow.axaml.cs
@@ -23,9 +23,14 @@ public partial class MainWindow : FAAppWindow
         TitleBar.ExtendsContentIntoTitleBar = true;
 
         InitializeComponent();
-        Background = SelectPlatformBackground(OperatingSystem.IsLinux(), Background);
+        Opened += ApplyPlatformBackground;
     }
 
     internal static IBrush? SelectPlatformBackground(bool isLinux, IBrush? currentBackground) =>
         isLinux ? currentBackground : Brushes.Transparent;
+
+    private void ApplyPlatformBackground(object? sender, EventArgs e)
+    {
+        Background = SelectPlatformBackground(OperatingSystem.IsLinux(), Background);
+    }
 }

--- a/tests/UnitTests/UI/MainWindowTests.cs
+++ b/tests/UnitTests/UI/MainWindowTests.cs
@@ -97,35 +97,30 @@ namespace CrowsNestMqtt.UnitTests.UI
             Assert.False(string.IsNullOrEmpty(mainWindow.Title));
         }
 
-        [AvaloniaFact]
-        public void ConfigurePlatformBackground_OnLinux_PreservesOpaqueBackground()
+        [Fact]
+        public void SelectPlatformBackground_OnLinux_PreservesOpaqueBackground()
         {
             // Arrange
-            var mainWindow = new MainWindow();
             var opaqueBackground = new SolidColorBrush(Colors.Black);
-            mainWindow.Background = opaqueBackground;
 
             // Act
-            mainWindow.ConfigurePlatformBackground(isLinux: true);
+            var background = MainWindow.SelectPlatformBackground(isLinux: true, opaqueBackground);
 
             // Assert
-            Assert.Same(opaqueBackground, mainWindow.Background);
+            Assert.Same(opaqueBackground, background);
         }
 
-        [AvaloniaFact]
-        public void ConfigurePlatformBackground_OnNonLinux_UsesTransparentBackground()
+        [Fact]
+        public void SelectPlatformBackground_OnNonLinux_UsesTransparentBackground()
         {
             // Arrange
-            var mainWindow = new MainWindow
-            {
-                Background = new SolidColorBrush(Colors.Black)
-            };
+            var opaqueBackground = new SolidColorBrush(Colors.Black);
 
             // Act
-            mainWindow.ConfigurePlatformBackground(isLinux: false);
+            var background = MainWindow.SelectPlatformBackground(isLinux: false, opaqueBackground);
 
             // Assert
-            Assert.Same(Brushes.Transparent, mainWindow.Background);
+            Assert.Same(Brushes.Transparent, background);
         }
 
         [AvaloniaFact]


### PR DESCRIPTION
## Summary
- run solution test projects sequentially during coverage collection
- prevent Avalonia headless dispatcher teardown races
- prevent performance tests from measuring cross-project CPU and I/O contention

## Failure analysis
The failed main run reported all tests passing before an Avalonia/xUnit catastrophic teardown exception. A rerun exposed the same concurrency issue as an Avalonia cross-thread cleanup failure and also caused a normally ~35 ms export performance test to take 1.98 s while four projects ran concurrently.